### PR TITLE
Address some flake8 errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,12 +61,7 @@ jobs:
         run: |
           # Stop the build if there are Python syntax errors or
           # undefined names.
-
-          # TODO: remove `--exit-zero` from the first invocation of
-          # flake8 once issue #14 is solved.  We should see that we
-          # can run tests on CI first, before addressing flake8's
-          # complaints.
-          python -m flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
+          python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
           # exit-zero treats all errors as warnings.
           python -m flake8 . --count --exit-zero --max-complexity=10 --statistics

--- a/swagger_server/messaging/message_queue_producer.py
+++ b/swagger_server/messaging/message_queue_producer.py
@@ -1,5 +1,6 @@
-import pika
+import json
 
+import pika
 
 class MetaClass(type):
     _instance = {}
@@ -56,8 +57,6 @@ if __name__ == "__main__":
         queue="hello", host="localhost", routingKey="hello", exchange=""
     )
 
-    image = Image(filename="local-ctlr-1.manifest")
-    data = image.get
-
-    with RabbitMq(server) as rabbitmq:
-        rabbitmq.publish(payload=data)
+    with open("./mq-test/local-ctlr-1/local-ctlr-1.manifest") as f:
+        data = json.load(f)
+        RabbitMq(server).publish(body=data)

--- a/swagger_server/test/test_topology_controller.py
+++ b/swagger_server/test/test_topology_controller.py
@@ -108,7 +108,7 @@ class TestTopologyController(BaseTestCase):
 
         uploads an topology image
         """
-        body = Object()
+        body = Topology()
         response = self.client.open(
             "/SDX-LC/1.0.0/topology/{topologyId}/uploadImage".format(topology_id=789),
             method="POST",


### PR DESCRIPTION
See issue #14.

This PR removes the two errors flake8 reported:

- `undefined name 'Object'`
- `undefined name 'Image'`

Also updates CI configuration so that this class of flake8 errors are actually treated as errors.  CI will error out if flake8 detects such errors again.

We can run `python ./swagger_server/messaging/message_queue_producer.py` as a smoke test now, if RabbitMQ is running.