### PR TITLE
Exit test suite when done

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,6 @@ jobs:
       - name: Run tests
         run: |
           python -m tox
-        timeout-minutes: 3
         env:
           SDXLC_HOST: 'localhost'
           SDXLC_DOMAIN: ''

--- a/swagger_server/controllers/topology_controller.py
+++ b/swagger_server/controllers/topology_controller.py
@@ -28,10 +28,6 @@ db_tuples = [("config_table", "test-config")]
 db_instance = DbUtils()
 db_instance._initialize_db(DB_NAME, db_tuples)
 
-# initiate rpc producer with 5 seconds timeout
-rpc = RpcProducer(5, "", "topo")
-
-
 def find_between(s, first, last):
     try:
         start = s.index(first) + len(first)
@@ -71,7 +67,12 @@ def add_topology(body):  # noqa: E501
     logger.debug("Saving to database complete.")
 
     logger.debug("Publishing Message to MQ: {}".format(body))
+
+    # initiate rpc producer with 5 seconds timeout
+    rpc = RpcProducer(5, "", "topo")
     response = rpc.call(json_body)
+    # Signal to end keep alive pings.
+    rpc.stop()
 
     return str(response)
 

--- a/swagger_server/messaging/rpc_queue_producer.py
+++ b/swagger_server/messaging/rpc_queue_producer.py
@@ -37,6 +37,10 @@ class RpcProducer(object):
         )
 
     def stop(self):
+        """
+        Signal to stop keep-alive pings, so that RpcProducer instances
+        can be safely deleted.
+        """
         self.stop_keep_live = True
 
     def keep_live(self):

--- a/swagger_server/messaging/rpc_queue_producer.py
+++ b/swagger_server/messaging/rpc_queue_producer.py
@@ -21,6 +21,8 @@ class RpcProducer(object):
         self.exchange_name = exchange_name
         self.routing_key = routing_key
 
+        self.stop_keep_live = False
+
         t1 = threading.Thread(target=self.keep_live, args=())
         t1.start()
 
@@ -34,8 +36,11 @@ class RpcProducer(object):
             auto_ack=True,
         )
 
+    def stop(self):
+        self.stop_keep_live = True
+
     def keep_live(self):
-        while True:
+        while self.stop_keep_live != True:
             time.sleep(30)
             msg = "[MQ]: Heart Beat"
             self.logger.debug("Sending heart beat msg.")
@@ -79,8 +84,9 @@ class RpcProducer(object):
 
 
 if __name__ == "__main__":
-    rpc = RpcProducer()
+    rpc = RpcProducer(timeout=1, exchange_name="", routing_key="test")
     body = "test body"
     print("Published Message: {}".format(body))
     response = rpc.call(body)
     print(" [.] Got response: " + str(response))
+    rpc.stop()

--- a/swagger_server/messaging/rpc_queue_producer.py
+++ b/swagger_server/messaging/rpc_queue_producer.py
@@ -89,7 +89,7 @@ class RpcProducer(object):
 
 if __name__ == "__main__":
     rpc = RpcProducer(
-        timeout=1, exchange_name="", routing_key="329a0137-23a8-4a9b-bd65-a3379f0d564e"
+        timeout=1, exchange_name="", routing_key=str(uuid.uuid4())
     )
     body = "test body"
     print("Published Message: {}".format(body))

--- a/swagger_server/messaging/rpc_queue_producer.py
+++ b/swagger_server/messaging/rpc_queue_producer.py
@@ -88,7 +88,9 @@ class RpcProducer(object):
 
 
 if __name__ == "__main__":
-    rpc = RpcProducer(timeout=1, exchange_name="", routing_key="test")
+    rpc = RpcProducer(
+        timeout=1, exchange_name="", routing_key="329a0137-23a8-4a9b-bd65-a3379f0d564e"
+    )
     body = "test body"
     print("Published Message: {}".format(body))
     response = rpc.call(body)


### PR DESCRIPTION
See issue #31.

Once `RpcProducer`  is instantiated, it will keep sending keep-alive pings to the message queue.  This PR adds an `RpcProducer.stop()` method which will signal that it should shut down, and uses the method from the test suite so that the test suite can terminate instead of continuing to run the thread for no good reason. 