### PR TITLE
Lint Dockerfile with hadolint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+venv*/
+.tox/

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,3 +38,8 @@ jobs:
       - name: Run "isort --check"
         run: |
           python -m isort --check --profile black .
+
+      - name: Lint sdx-lc Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -9,10 +9,10 @@ on:
       - "main"
     tags:
       - "*"
-  # Triggering the build/publish of container images on pull
-  # requests should be here only for testing, keep "pull_request"
-  # disabled.
-  pull_request:
+  # # Triggering the build/publish of container images on pull
+  # # requests should be here only for testing, keep "pull_request"
+  # # disabled.
+  # pull_request:
 
 permissions:
   contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-#FROM python:3.6-alpine
-FROM python:3.9.6-buster
+FROM python:3.9-slim-bullseye
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /usr/src/app
 COPY requirements.txt /usr/src/app/
 
 RUN pip3 install --no-cache-dir -r requirements.txt
-RUN pip3 install "connexion[swagger-ui]"
 
 COPY . /usr/src/app
 


### PR DESCRIPTION
Issue is #80. Changes:

- Lint Dockerfile with hadolint.
- Add hadolint as a CI step.
- Ignore some directories (venv, .git, .tox) when building images.
- Use a smaller base image. On a quick check with `podman build`, I now get an image of 197 MB, whereas image size when using the `python:3.9.6-buster` base image is 975 MB.
- Disable building/publishing container images on pull requests. Images will be built and published only on commits to main, or when a tag (meaning, a release) has been pushed.