### PR TITLE
convert mongo key to str

### DIFF
--- a/swagger_server/utils/db_utils.py
+++ b/swagger_server/utils/db_utils.py
@@ -33,6 +33,7 @@ class DbUtils(object):
 
     def add_key_value_pair_to_db(self, key, value):
         """Add key value pair to database"""
+        key = str(key)
         obj = self.read_from_db(key)
         if obj is None:
             self.logger.debug("Adding key value pair to DB.")
@@ -49,6 +50,7 @@ class DbUtils(object):
 
     def read_from_db(self, key):
         """Given a user specified key, return the value stored in database"""
+        key = str(key)
         return self.sdxdb[self.db_name][self.config_table_name].find_one(
             {key: {"$exists": 1}}
         )


### PR DESCRIPTION
This converts all keys to string for mongodb read and write, because Mongodb requires keys to be string.