### PR TITLE
Change ingress_port and egress_port with uni_a and uni_z respectively 

### DIFF
--- a/swagger_server/messaging/topic_queue_consumer.py
+++ b/swagger_server/messaging/topic_queue_consumer.py
@@ -93,7 +93,7 @@ class TopicQueueConsumer(object):
         if is_json(msg_body):
             self.logger.info("JSON message")
             msg_json = json.loads(msg_body)
-            if "ingress_port" in msg_json and "egress_port" in msg_json:
+            if "uni_a" in msg_json and "uni_z" in msg_json:
                 self.logger.info("Got connection message.")
                 self.db_instance.add_key_value_pair_to_db(self.message_id, msg_body)
                 self.logger.info("Save to database complete.")


### PR DESCRIPTION
Fixes #102 

Head-up: this PR sits on top of PR #107 

## Description of the change

- To be conform with SDX-Controller breakdown connections request, this PR changes the attributes ingress_port and egress_port with uni_a and uni_z (https://github.com/atlanticwave-sdx/pce/blob/main/src/sdx_pce/models.py#L122-L123)

