### PR TITLE
Use empty queue name

### DIFF
--- a/swagger_server/messaging/topic_queue_consumer.py
+++ b/swagger_server/messaging/topic_queue_consumer.py
@@ -43,7 +43,7 @@ class TopicQueueConsumer(object):
         self.channel = self.connection.channel()
         self.exchange_name = exchange_name
 
-        self.result = self.channel.queue_declare(queue=SUB_QUEUE)
+        self.result = self.channel.queue_declare(queue="", exclusive=True)
         self._thread_queue = thread_queue
 
         self.binding_keys = []


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-lc/issues/109

Sometimes topic queue consumer receives RabbitMQ message from wrong OXP. So update with an empty queue name, and later bind it to a unique queue. As suggested in [this](https://github.com/atlanticwave-sdx/sdx-lc/issues/109#issuecomment-2035178647) comment, this is also used by RabbitMQ tutorial.