### PR TITLE
Use tox-docker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
           python -m tox
         env:
           SDXLC_HOST: 'localhost'
-          SDXLC_DOMAIN: 'test_topology.net'
+          SDXLC_DOMAIN: 'example.net'
           SDXLC_PORT: '8080'
           SDXLC_VERSION: '1.0.0'
           SDXLC_NAME: 'test-lc'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
           MQ_USER: 'guest'
           MQ_PASS: 'guest'
           MQ_NAME: 'hello'
-          MQ_EXCHANGE: ''          
+          MQ_EXCHANGE: ''
           SUB_QUEUE: 'test-queue'
           SUB_TOPIC: 'test-topic'
           SUB_EXCHANGE: 'test-exchange'

--- a/README.md
+++ b/README.md
@@ -88,10 +88,12 @@ $ python3 -m sdx_lc
 
 ## Running tests
 
-To launch the integration tests, use tox:
+To run tests, use [tox] and [tox-docker]:
 
 ```console
-$ pip install tox
+$ python3 -m venv venv --upgrade-deps
+$ source venv/bin/activate
+$ pip install tox tox-docker
 $ tox
 ```
 
@@ -129,3 +131,6 @@ Local controller sends domain information to SDX controller:
 
 [sdx-controller-to-lc]: https://user-images.githubusercontent.com/29924060/139590360-d6c9aaef-e9ba-4c32-a8f9-7a0644b4b35f.jpg
 [sdx-lc-to-controller]: https://user-images.githubusercontent.com/29924060/139590365-361b4f46-984c-4ab6-8d47-83c9c362910b.jpg
+
+[tox]: https://tox.wiki/en/latest/
+[tox-docker]: https://tox-docker.readthedocs.io/

--- a/sdx_lc/test/test_topology_controller.py
+++ b/sdx_lc/test/test_topology_controller.py
@@ -69,7 +69,7 @@ class TestTopologyController(BaseTestCase):
     ]
 
     __topology = Topology(
-        id="test:topology:test_topology.net",
+        id="test:topology:example.net",
         name="test_topology_name",
         services=None,
         version=0,

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,49 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        pytest>=7.1.2
        pytest-cov>=3.0.0
-passenv = SDXLC_*, MQ_*, SUB_*, DB_*, MONGODB_CONNSTRING
+
+setenv =
+    SDXLC_DOMAIN = test_topology.net
+    SDXLC_HOST = localhost
+    SDXLC_PORT = 8082
+    SDXLC_VERSION = 2.0.0
+    SDXLC_NAME = test-sdx-lc
+    MQ_NAME = test-mq
+    MQ_HOST = localhost
+    MQ_PORT = 5672
+    MQ_USER = guest
+    MQ_PASS = guest
+    MQ_EXCHANGE = ''
+    SUB_QUEUE = connection
+    SUB_EXCHANGE = connection
+    MONGODB_CONNSTRING = mongodb://guest:guest@localhost:27017/
+    DB_NAME = test-db
+    DB_CONFIG_TABLE_NAME = test-table
+
 commands =
     pytest --cov=sdx_lc {posargs}
+
+docker =
+    rabbitmq
+    mongo
+
+
+[docker:rabbitmq]
+image = rabbitmq:latest
+
+ports =
+    5672:5672/tcp
+
+healthcheck_cmd = rabbitmq-diagnostics -q ping
+
+[docker:mongo]
+image = mongo:7.0.5
+
+ports =
+    27017:27017/tcp
+
+environment =
+    MONGO_INITDB_ROOT_USERNAME=guest
+    MONGO_INITDB_ROOT_PASSWORD=guest
+
+healthcheck_cmd = mongosh localhost:27017/test --quiet

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps = -r{toxinidir}/requirements.txt
        pytest-cov>=3.0.0
 
 setenv =
-    SDXLC_DOMAIN = test_topology.net
+    SDXLC_DOMAIN = example.net
     SDXLC_HOST = localhost
     SDXLC_PORT = 8082
     SDXLC_VERSION = 2.0.0


### PR DESCRIPTION
Resolves #121. Changes:

- Use tox-docker to spin up services when testing with `tox`.
- Update testing instructions
