### PR TITLE
Update SUB_TOPIC to be same as SDXLC_DOMAIN

### DIFF
--- a/env.template
+++ b/env.template
@@ -30,7 +30,7 @@ export MQ_PASS="guest"
 
 export SUB_QUEUE="connection"
 export SUB_EXCHANGE="connection"
-export SUB_TOPIC="lc1_q1"
+export SUB_TOPIC=${SDXLC_DOMAIN}
 
 # Kytos/OESS API address
 export OXP_PROVISION_URL='http://192.168.201.205:8088/SDX-LC/1.0.0/provision'


### PR DESCRIPTION
Use the LC domain as MQ routing key to avoid confusion.