### PR TITLE
Simplify message queue configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,6 @@ jobs:
           MQ_PORT: '5672'
           MQ_USER: 'guest'
           MQ_PASS: 'guest'
-          SUB_TOPIC: 'test-topic'
           DB_NAME: 'test-db'
           DB_CONFIG_TABLE_NAME: 'test-config-table'
           MONGODB_CONNSTRING: 'mongodb://guest:guest@localhost:27017/'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,16 +78,16 @@ jobs:
           python -m coverage lcov -o coverage.lcov
         env:
           SDXLC_HOST: 'localhost'
-          SDXLC_DOMAIN: 'example.net'
           SDXLC_PORT: '8080'
+          SDXLC_DOMAIN: 'example.net'
           SDXLC_NAME: 'test-lc'
           MQ_HOST: 'localhost'
           MQ_PORT: '5672'
           MQ_USER: 'guest'
           MQ_PASS: 'guest'
+          MONGODB_CONNSTRING: 'mongodb://guest:guest@localhost:27017/'
           DB_NAME: 'test-db'
           DB_CONFIG_TABLE_NAME: 'test-config-table'
-          MONGODB_CONNSTRING: 'mongodb://guest:guest@localhost:27017/'
 
       - name: Send coverage data to coveralls.io
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,6 @@ jobs:
           MQ_PORT: '5672'
           MQ_USER: 'guest'
           MQ_PASS: 'guest'
-          SUB_QUEUE: 'test-queue'
           SUB_TOPIC: 'test-topic'
           SUB_EXCHANGE: 'test-exchange'
           DB_NAME: 'test-db'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,6 @@ jobs:
           MQ_USER: 'guest'
           MQ_PASS: 'guest'
           SUB_TOPIC: 'test-topic'
-          SUB_EXCHANGE: 'test-exchange'
           DB_NAME: 'test-db'
           DB_CONFIG_TABLE_NAME: 'test-config-table'
           MONGODB_CONNSTRING: 'mongodb://guest:guest@localhost:27017/'

--- a/compose.yml
+++ b/compose.yml
@@ -46,8 +46,6 @@ services:
       - MQ_PORT=${MQ_PORT}
       - MQ_USER=${MQ_USER}
       - MQ_PASS=${MQ_PASS}
-      - SUB_EXCHANGE=${SUB_EXCHANGE}
-      - SUB_TOPIC=${SUB_TOPIC}
       # OXP settings.
       - OXP_CONNECTION_URL=${OXP_CONNECTION_URL}
       - OXP_PULL_URL=${OXP_PULL_URL}

--- a/compose.yml
+++ b/compose.yml
@@ -46,7 +46,6 @@ services:
       - MQ_PORT=${MQ_PORT}
       - MQ_USER=${MQ_USER}
       - MQ_PASS=${MQ_PASS}
-      - SUB_QUEUE=${SUB_QUEUE}
       - SUB_EXCHANGE=${SUB_EXCHANGE}
       - SUB_TOPIC=${SUB_TOPIC}
       # OXP settings.

--- a/env.template
+++ b/env.template
@@ -28,8 +28,6 @@ export MQ_PORT=5672
 export MQ_USER="guest"
 export MQ_PASS="guest"
 
-export SUB_TOPIC="lc1_q1"
-
 # Kytos/OESS API address
 export OXP_PROVISION_URL='http://192.168.201.205:8088/SDX-LC/1.0.0/provision'
 export OXP_PULL_URL='http://192.168.201.205:8088/SDX-LC/1.0.0/topology'

--- a/env.template
+++ b/env.template
@@ -28,7 +28,6 @@ export MQ_PORT=5672
 export MQ_USER="guest"
 export MQ_PASS="guest"
 
-export SUB_QUEUE="connection"
 export SUB_EXCHANGE="connection"
 export SUB_TOPIC="lc1_q1"
 

--- a/env.template
+++ b/env.template
@@ -28,7 +28,6 @@ export MQ_PORT=5672
 export MQ_USER="guest"
 export MQ_PASS="guest"
 
-export SUB_EXCHANGE="connection"
 export SUB_TOPIC="lc1_q1"
 
 # Kytos/OESS API address

--- a/sdx_lc/__main__.py
+++ b/sdx_lc/__main__.py
@@ -29,6 +29,14 @@ def is_json(myjson):
 
 
 def start_consumer(thread_queue, db_instance):
+    """
+    Accept connection (also called link) messages from SDX Controller.
+
+    :param thread_queue: TODO: unsure what this is used for.
+    :param db_instance: TODO: this appears to be unused in this
+        function.
+    """
+
     MESSAGE_ID = 0
     HEARTBEAT_ID = 0
 

--- a/sdx_lc/__main__.py
+++ b/sdx_lc/__main__.py
@@ -32,7 +32,7 @@ def start_consumer(thread_queue, db_instance):
     MESSAGE_ID = 0
     HEARTBEAT_ID = 0
 
-    rpc = TopicQueueConsumer(thread_queue, "connection")
+    rpc = TopicQueueConsumer(thread_queue=thread_queue, exchange_name="connection")
     t1 = threading.Thread(target=rpc.start_consumer, args=())
     t1.start()
 

--- a/sdx_lc/controllers/topology_controller.py
+++ b/sdx_lc/controllers/topology_controller.py
@@ -56,7 +56,6 @@ def add_topology(body):  # noqa: E501
         logger.debug("Domain name not matching LC domain. Returning 400 status.")
         return "Domain name not matching LC domain. Please check again.", 400
 
-    body["lc_queue_name"] = os.environ.get("SUB_TOPIC")
     json_body = json.dumps(body)
 
     logger.debug("Adding topology. Saving to database.")

--- a/sdx_lc/messaging/topic_queue_consumer.py
+++ b/sdx_lc/messaging/topic_queue_consumer.py
@@ -15,8 +15,6 @@ MQ_PORT = os.environ.get("MQ_PORT")
 MQ_USER = os.environ.get("MQ_USER")
 MQ_PASS = os.environ.get("MQ_PASS")
 
-# subscribe to the corresponding queue
-SUB_TOPIC = os.environ.get("SUB_TOPIC")
 OXP_CONNECTION_URL = os.environ.get("OXP_CONNECTION_URL")
 
 

--- a/sdx_lc/messaging/topic_queue_consumer.py
+++ b/sdx_lc/messaging/topic_queue_consumer.py
@@ -17,7 +17,6 @@ MQ_PASS = os.environ.get("MQ_PASS")
 
 # subscribe to the corresponding queue
 SUB_TOPIC = os.environ.get("SUB_TOPIC")
-SUB_EXCHANGE = os.environ.get("SUB_EXCHANGE")
 OXP_CONNECTION_URL = os.environ.get("OXP_CONNECTION_URL")
 
 
@@ -127,12 +126,14 @@ class TopicQueueConsumer(object):
 
     def start_consumer(self):
         # self.channel.queue_declare(queue=SUB_QUEUE)
-        self.channel.exchange_declare(exchange=SUB_EXCHANGE, exchange_type="topic")
+        self.channel.exchange_declare(
+            exchange=self.exchange_name, exchange_type="topic"
+        )
         queue_name = self.result.method.queue
         # print('queue_name: ' + queue_name)
 
         self.channel.queue_bind(
-            exchange=SUB_EXCHANGE, queue=queue_name, routing_key=self.routing_key
+            exchange=self.exchange_name, queue=queue_name, routing_key=self.routing_key
         )
 
         self.channel.basic_qos(prefetch_count=1)
@@ -143,7 +144,8 @@ class TopicQueueConsumer(object):
 
         self.logger.info(
             f" [MQ] Awaiting requests from queue:'{queue_name}'"
-            f" with routing_key:'{self.routing_key}'"
+            f" with exchange_name: '{self.exchange_name}'"
+            f" routing_key:'{self.routing_key}'"
             f" (MQ_HOST: {MQ_HOST}, MQ_PORT: {MQ_PORT})"
         )
 

--- a/sdx_lc/messaging/topic_queue_consumer.py
+++ b/sdx_lc/messaging/topic_queue_consumer.py
@@ -14,8 +14,8 @@ MQ_HOST = os.environ.get("MQ_HOST")
 MQ_PORT = os.environ.get("MQ_PORT")
 MQ_USER = os.environ.get("MQ_USER")
 MQ_PASS = os.environ.get("MQ_PASS")
+
 # subscribe to the corresponding queue
-SUB_QUEUE = os.environ.get("SUB_QUEUE")
 SUB_TOPIC = os.environ.get("SUB_TOPIC")
 SUB_EXCHANGE = os.environ.get("SUB_EXCHANGE")
 OXP_CONNECTION_URL = os.environ.get("OXP_CONNECTION_URL")

--- a/sdx_lc/messaging/topic_queue_consumer.py
+++ b/sdx_lc/messaging/topic_queue_consumer.py
@@ -46,8 +46,7 @@ class TopicQueueConsumer(object):
         self.result = self.channel.queue_declare(queue="", exclusive=True)
         self._thread_queue = thread_queue
 
-        self.binding_keys = []
-        self.binding_keys.append(SUB_TOPIC)
+        self.routing_key = os.getenv("SDXLC_DOMAIN")
 
         # Get DB connection and tables set up.
         self.db_instance = DbUtils()
@@ -132,11 +131,9 @@ class TopicQueueConsumer(object):
         queue_name = self.result.method.queue
         # print('queue_name: ' + queue_name)
 
-        # binding to: queue--'', exchange--connection, routing_key--lc1_q1
-        for binding_key in self.binding_keys:
-            self.channel.queue_bind(
-                exchange=SUB_EXCHANGE, queue=queue_name, routing_key=binding_key
-            )
+        self.channel.queue_bind(
+            exchange=SUB_EXCHANGE, queue=queue_name, routing_key=self.routing_key
+        )
 
         self.channel.basic_qos(prefetch_count=1)
 

--- a/sdx_lc/messaging/topic_queue_consumer.py
+++ b/sdx_lc/messaging/topic_queue_consumer.py
@@ -141,7 +141,12 @@ class TopicQueueConsumer(object):
             queue=queue_name, on_message_callback=self.callback, auto_ack=True
         )
 
-        self.logger.info(" [MQ] Awaiting requests from queue: " + SUB_QUEUE)
+        self.logger.info(
+            f" [MQ] Awaiting requests from queue:'{queue_name}'"
+            f" with routing_key:'{self.routing_key}'"
+            f" (MQ_HOST: {MQ_HOST}, MQ_PORT: {MQ_PORT})"
+        )
+
         self.channel.start_consuming()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ setenv =
     MQ_USER = guest
     MQ_PASS = guest
     SUB_QUEUE = connection
-    SUB_EXCHANGE = connection
     MONGODB_CONNSTRING = mongodb://guest:guest@localhost:27017/
     DB_NAME = test-db
     DB_CONFIG_TABLE_NAME = test-table

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,9 @@ deps =
     [test]
 
 setenv =
-    SDXLC_DOMAIN = example.net
     SDXLC_HOST = localhost
     SDXLC_PORT = 8082
+    SDXLC_DOMAIN = example.net
     SDXLC_NAME = test-sdx-lc
     MQ_HOST = localhost
     MQ_PORT = 5672

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ setenv =
     MQ_PORT = 5672
     MQ_USER = guest
     MQ_PASS = guest
-    SUB_QUEUE = connection
     MONGODB_CONNSTRING = mongodb://guest:guest@localhost:27017/
     DB_NAME = test-db
     DB_CONFIG_TABLE_NAME = test-table


### PR DESCRIPTION
Resolves #137: gets rid of some environment variables (`SUB_QUEUE`, `SUB_EXCHANGE`, `SUB_TOPIC`), and use defaults instead.

We do not need a queue name. We do need an exchange name (which would be just "connection") to receive connection/link messages published by SDX-Controller. SUB_TOPIC is not really ever used.

This is stacked on top of #142; please review that PR first.
