### PR TITLE
Use tox-docker `expose` directive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,10 @@ jobs:
           MQ_PORT: '5672'
           MQ_USER: 'guest'
           MQ_PASS: 'guest'
-          MONGODB_CONNSTRING: 'mongodb://guest:guest@localhost:27017/'
+          MONGO_HOST: 'localhost'
+          MONGO_PORT: '27017'
+          MONGO_USER: 'guest'
+          MONGO_PASS: 'guest'
           DB_NAME: 'test-db'
           DB_CONFIG_TABLE_NAME: 'test-config-table'
 

--- a/README.md
+++ b/README.md
@@ -162,3 +162,4 @@ Local controller sends domain information to SDX controller:
 
 [tox]: https://tox.wiki/en/latest/
 [tox-docker]: https://tox-docker.readthedocs.io/
+[pytest]: https://docs.pytest.org/

--- a/README.md
+++ b/README.md
@@ -97,6 +97,34 @@ $ pip install 'tox>=4' 'tox-docker>=5'
 $ tox
 ```
 
+### With pytest
+
+If you want to avoid tox and run [pytest] directly, that is possible
+too.  You will need to run RabbitMQ and MongoDB, with Docker perhaps.
+See above for the steps.
+
+Some environment variables are expected to be set for the tests to
+work as expected, so you may want to copy `env.template` to `.env` and
+edit it according to your environment, and make sure the env vars are
+present in your shell:
+
+```console
+$ cp env.template .env 
+$ # and then edit .env to suit your environment
+$ source .env
+```
+
+And now, activate a virtual environment, install the requirements, and
+then run `pytest`:
+
+```
+$ python3 -m venv venv --upgrade-deps
+$ source ./venv/bin/activate
+$ pip3 install --editable .[test]
+$ pytest
+```
+`
+
 ## Communication between SDX Controller and Local Controller
 
 The SDX controller and local controller communicate using

--- a/README.md
+++ b/README.md
@@ -85,12 +85,15 @@ $ python3 -m sdx_lc
 
 ## Running tests
 
-To run tests, use [tox] and [tox-docker]:
+### With tox
+
+An easy way to run tests is using [tox] and [tox-docker].  You will
+need Docker installed and running.
 
 ```console
 $ python3 -m venv venv --upgrade-deps
 $ source venv/bin/activate
-$ pip install 'tox>=4' tox-docker
+$ pip install 'tox>=4' 'tox-docker>=5'
 $ tox
 ```
 

--- a/compose.yml
+++ b/compose.yml
@@ -5,8 +5,8 @@ services:
     expose:
       - ${MONGO_PORT}
     environment:
-      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}
-      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-guest}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:-guest}
     volumes:
       # See https://docs.docker.com/storage/volumes/
       #
@@ -52,9 +52,9 @@ services:
       - DB_CONFIG_TABLE_NAME=${DB_CONFIG_TABLE_NAME}
       # Message queue settings.
       - MQ_HOST=${MQ_HOST}
-      - MQ_PORT=${MQ_PORT}
-      - MQ_USER=${MQ_USER}
-      - MQ_PASS=${MQ_PASS}
+      - MQ_PORT=${MQ_PORT:-5672}
+      - MQ_USER=${MQ_USER:-guest}
+      - MQ_PASS=${MQ_PASS:-guest}
       # OXP settings.
       - OXP_PROVISION_URL=${OXP_PROVISION_URL}
       - OXP_PULL_URL=${OXP_PULL_URL}

--- a/compose.yml
+++ b/compose.yml
@@ -44,7 +44,10 @@ services:
       - SDXLC_PORT=${SDXLC_PORT}
       # MongoDB settings.  When using compose, we connect to the
       # mongodb service started by compose.
-      - MONGODB_CONNSTRING=mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongodb:${MONGO_PORT}/
+      - MONGO_HOST=mongodb
+      - MONGO_PORT=${MONGO_PORT:-27017}
+      - MONGO_USER=${MONGO_USER:-guest}
+      - MONGO_PASS=${MONGO_PASS:-guest}
       - DB_NAME=${DB_NAME}
       - DB_CONFIG_TABLE_NAME=${DB_CONFIG_TABLE_NAME}
       # Message queue settings.

--- a/env.template
+++ b/env.template
@@ -8,14 +8,16 @@ export SDXLC_DOMAIN='amlight.net'
 export SDXLC_HOST="aw-sdx-lc-1.renci.org"
 export SDXLC_PORT="8080"
 
-# To run tests locally (with tox or pytest) or to run the server
-# without Docker Compose, localhost is convenient as MONGO_HOST; for
-# Docker Compose, we hard-code the container name in the compose file.
-export MONGO_HOST="localhost"
-export MONGO_PORT="27017"
+# Used in initial MongoDB container setup.
 export MONGO_INITDB_ROOT_USERNAME="guest"
 export MONGO_INITDB_ROOT_PASSWORD="guest"
-export MONGODB_CONNSTRING="mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/"
+
+# Used when accessing MongoDB.
+export MONGO_HOST="localhost"
+export MONGO_PORT="27017"
+export MONGO_USER="guest"
+export MONGO_PASS="guest"
+
 export SDXLC_MONGO_DB="sdx-controllder-test-db"
 export SDXLC_MONGO_COLLECTION="sdx-controller-test-table"
 

--- a/env.template
+++ b/env.template
@@ -18,9 +18,6 @@ export MONGO_PORT="27017"
 export MONGO_USER="guest"
 export MONGO_PASS="guest"
 
-export SDXLC_MONGO_DB="sdx-controllder-test-db"
-export SDXLC_MONGO_COLLECTION="sdx-controller-test-table"
-
 export DB_NAME='test-db'
 export DB_CONFIG_TABLE_NAME='test-1'
 

--- a/sdx_lc/utils/db_utils.py
+++ b/sdx_lc/utils/db_utils.py
@@ -5,16 +5,37 @@ import pymongo
 
 DB_NAME = os.environ.get("DB_NAME")
 DB_CONFIG_TABLE_NAME = os.environ.get("DB_CONFIG_TABLE_NAME")
-MONGODB_CONNSTRING = os.environ.get("MONGODB_CONNSTRING")
 
 
 class DbUtils(object):
     def __init__(self):
         self.db_name = DB_NAME
         self.config_table_name = DB_CONFIG_TABLE_NAME
-        self.mongo_client = pymongo.MongoClient(MONGODB_CONNSTRING)
+
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.DEBUG)
+
+        mongo_user = os.getenv("MONGO_USER") or "guest"
+        mongo_pass = os.getenv("MONGO_PASS") or "guest"
+        mongo_host = os.getenv("MONGO_HOST")
+        mongo_port = os.getenv("MONGO_PORT")
+
+        if mongo_host is None:
+            raise Exception("MONGO_HOST environment variable is not set")
+
+        if mongo_port is None:
+            raise Exception("MONGO_PORT environment variable is not set")
+
+        mongo_connstring = (
+            f"mongodb://{mongo_user}:{mongo_pass}@{mongo_host}:{mongo_port}/"
+        )
+
+        # Log DB URI, without a password.
+        self.logger.info(
+            f"[DB] Using mongodb://{mongo_user}@{mongo_host}:{mongo_port}/"
+        )
+
+        self.mongo_client = pymongo.MongoClient(mongo_connstring)
 
     def initialize_db(self):
         """Init database"""

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,9 @@ docker =
 [docker:rabbitmq]
 image = rabbitmq:latest
 
+# This will update MQ_HOST in testenv.
+host_var = MQ_HOST
+
 # This will update MQ_PORT in testenv.
 expose =
     MQ_PORT=5672/tcp
@@ -42,6 +45,9 @@ healthcheck_cmd = rabbitmq-diagnostics -q ping
 
 [docker:mongo]
 image = mongo:7.0.11
+
+# This will update MONGO_HOST in testenv.
+host_var = MONGO_HOST
 
 # This will update MONGO_PORT in testenv.
 expose =

--- a/tox.ini
+++ b/tox.ini
@@ -31,20 +31,21 @@ docker =
     rabbitmq
     mongo
 
-
 [docker:rabbitmq]
 image = rabbitmq:latest
 
-ports =
-    5672:5672/tcp
+# This will update MQ_PORT in testenv.
+expose =
+    MQ_PORT=5672/tcp
 
 healthcheck_cmd = rabbitmq-diagnostics -q ping
 
 [docker:mongo]
 image = mongo:7.0.11
 
-ports =
-    27017:27017/tcp
+# This will update MONGO_PORT in testenv.
+expose =
+    MONGO_PORT=27017/tcp
 
 environment =
     MONGO_INITDB_ROOT_USERNAME=guest

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,10 @@ setenv =
     MQ_PORT = 5672
     MQ_USER = guest
     MQ_PASS = guest
-    MONGODB_CONNSTRING = mongodb://guest:guest@localhost:27017/
+    MONGO_USER = guest
+    MONGO_PASS = guest
+    MONGO_HOST = localhost
+    MONGO_PORT = 27017
     DB_NAME = test-db
     DB_CONFIG_TABLE_NAME = test-table
 


### PR DESCRIPTION
Resolves #147 by splitting `MONGODB_CONNSTRING` to `MONGO_HOST`, `MONGO_PORT`, `MONGO_USER`, and `MONGO_PASS`.

Similar to https://github.com/atlanticwave-sdx/sdx-controller/pull/292.

