### PR TITLE
Use `MONGODB_CONNSTRING` when `MONGO_HOST` is not set

### DIFF
--- a/env.template
+++ b/env.template
@@ -18,6 +18,12 @@ MONGO_PORT=27017
 MONGO_USER=guest
 MONGO_PASS=guest
 
+# # Alternative to specifying the above variables for accessing
+# # MongoDB, you can unset MONGO_HOST etc and use MONGODB_CONNSTRING
+# # instead. This appears to be useful when using a MongoDB replica
+# # set.  See https://github.com/atlanticwave-sdx/sdx-lc/issues/153.
+# MONGODB_CONNSTRING=mongodb://guest:guest@localhost:27017/
+
 DB_NAME=test-db
 DB_CONFIG_TABLE_NAME=test-1
 

--- a/sdx_lc/utils/db_utils.py
+++ b/sdx_lc/utils/db_utils.py
@@ -21,14 +21,16 @@ class DbUtils(object):
         mongo_port = os.getenv("MONGO_PORT")
 
         if mongo_host is None:
-            raise Exception("MONGO_HOST environment variable is not set")
+            mongo_connstring = os.getenv("MONGODB_CONNSTRING")
+            if mongo_connstring is None:
+                raise Exception("Neither MONGO_HOST nor MONGODB_CONNSTRING is set")
 
         if mongo_port is None:
             raise Exception("MONGO_PORT environment variable is not set")
-
-        mongo_connstring = (
-            f"mongodb://{mongo_user}:{mongo_pass}@{mongo_host}:{mongo_port}/"
-        )
+        else:
+            mongo_connstring = (
+                f"mongodb://{mongo_user}:{mongo_pass}@{mongo_host}:{mongo_port}/"
+            )
 
         # Log DB URI, without a password.
         self.logger.info(

--- a/sdx_lc/utils/db_utils.py
+++ b/sdx_lc/utils/db_utils.py
@@ -33,15 +33,12 @@ class DbUtils(object):
         mongo_user = os.getenv("MONGO_USER") or "guest"
         mongo_pass = os.getenv("MONGO_PASS") or "guest"
         mongo_host = os.getenv("MONGO_HOST")
-        mongo_port = os.getenv("MONGO_PORT")
+        mongo_port = os.getenv("MONGO_PORT") or 27017
 
         if mongo_host is None:
             mongo_connstring = os.getenv("MONGODB_CONNSTRING")
             if mongo_connstring is None:
                 raise Exception("Neither MONGO_HOST nor MONGODB_CONNSTRING is set")
-
-        if mongo_port is None:
-            raise Exception("MONGO_PORT environment variable is not set")
         else:
             mongo_connstring = (
                 f"mongodb://{mongo_user}:{mongo_pass}@{mongo_host}:{mongo_port}/"

--- a/sdx_lc/utils/db_utils.py
+++ b/sdx_lc/utils/db_utils.py
@@ -1,10 +1,22 @@
 import logging
 import os
+from urllib.parse import urlparse
 
 import pymongo
 
 DB_NAME = os.environ.get("DB_NAME")
 DB_CONFIG_TABLE_NAME = os.environ.get("DB_CONFIG_TABLE_NAME")
+
+
+def obfuscate_password_in_uri(uri: str) -> str:
+    """
+    Replace password field in URIs with a `*`, for logging.
+    """
+    parts = urlparse(uri)
+    if parts.password:
+        return f"{parts.scheme}://{parts.username}:*@{parts.hostname}:{parts.port}/"
+    else:
+        return uri
 
 
 class DbUtils(object):
@@ -33,9 +45,7 @@ class DbUtils(object):
             )
 
         # Log DB URI, without a password.
-        self.logger.info(
-            f"[DB] Using mongodb://{mongo_user}@{mongo_host}:{mongo_port}/"
-        )
+        self.logger.info(f"[DB] Using {obfuscate_password_in_uri(mongo_connstring)}")
 
         self.mongo_client = pymongo.MongoClient(mongo_connstring)
 

--- a/sdx_lc/utils/db_utils.py
+++ b/sdx_lc/utils/db_utils.py
@@ -5,9 +5,6 @@ from urllib.parse import urlparse
 import pymongo
 
 
-DB_CONFIG_TABLE_NAME = os.environ.get("DB_CONFIG_TABLE_NAME")
-
-
 def obfuscate_password_in_uri(uri: str) -> str:
     """
     Replace password field in URIs with a `*`, for logging.
@@ -22,11 +19,13 @@ def obfuscate_password_in_uri(uri: str) -> str:
 class DbUtils(object):
     def __init__(self):
         self.db_name = os.getenv("DB_NAME")
+        self.config_table_name = os.getenv("DB_CONFIG_TABLE_NAME")
 
         if not self.db_name:
             raise Exception("DB_NAME environment variable is not set")
 
-        self.config_table_name = DB_CONFIG_TABLE_NAME
+        if not self.config_table_name:
+            raise Exception("DB_CONFIG_TABLE_NAME environment variable is not set")
 
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.DEBUG)

--- a/sdx_lc/utils/db_utils.py
+++ b/sdx_lc/utils/db_utils.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 import pymongo
 
-DB_NAME = os.environ.get("DB_NAME")
+
 DB_CONFIG_TABLE_NAME = os.environ.get("DB_CONFIG_TABLE_NAME")
 
 
@@ -21,7 +21,11 @@ def obfuscate_password_in_uri(uri: str) -> str:
 
 class DbUtils(object):
     def __init__(self):
-        self.db_name = DB_NAME
+        self.db_name = os.getenv("DB_NAME")
+
+        if not self.db_name:
+            raise Exception("DB_NAME environment variable is not set")
+
         self.config_table_name = DB_CONFIG_TABLE_NAME
 
         self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
Resolves #153.  When `MONGO_HOST` is not set, try to use `MONGODB_CONNSTRING` (basically falls back to the old method of specifying the MongoDB URI), and fail when neither is set.

@italovalcy, does this work for you? 
