### PR TITLE
Change SDX-LC swagger spec to comply with topology spec 2.0.0

### DIFF
--- a/sdx_lc/models/link.py
+++ b/sdx_lc/models/link.py
@@ -32,7 +32,7 @@ class Link(Model):
         availability=None,
         status=None,
         state=None,
-        private_attributes=None,
+        private=None,
         timestamp=None,
         measurement_period=None,
     ):  # noqa: E501
@@ -60,8 +60,8 @@ class Link(Model):
         :type status: str
         :param state: The state of this Link.  # noqa: E501
         :type state: str
-        :param private_attributes: The private_attributes of this Link.  # noqa: E501
-        :type private_attributes: List[str]
+        :param private: The private attributes of this Link.  # noqa: E501
+        :type private: List[str]
         :param timestamp: The timestamp of this Link.  # noqa: E501
         :type timestamp: datetime
         :param measurement_period: The measurement_period of this Link.  # noqa: E501
@@ -79,7 +79,7 @@ class Link(Model):
             "availability": float,
             "status": str,
             "state": str,
-            "private_attributes": List[str],
+            "private": List[str],
             "timestamp": datetime,
             "measurement_period": LinkMeasurementPeriod,
         }
@@ -96,7 +96,7 @@ class Link(Model):
             "availability": "availability",
             "status": "status",
             "state": "state",
-            "private_attributes": "private_attributes",
+            "private": "private",
             "timestamp": "timestamp",
             "measurement_period": "measurement_period",
         }
@@ -111,7 +111,7 @@ class Link(Model):
         self._availability = availability
         self._status = status
         self._state = state
-        self._private_attributes = private_attributes
+        self._private = private
         self._timestamp = timestamp
         self._measurement_period = measurement_period
 
@@ -368,25 +368,25 @@ class Link(Model):
         self._state = state
 
     @property
-    def private_attributes(self):
-        """Gets the private_attributes of this Link.
+    def private(self):
+        """Gets the private attributes of this Link.
 
 
-        :return: The private_attributes of this Link.
+        :return: The private attributes of this Link.
         :rtype: List[str]
         """
-        return self._private_attributes
+        return self._private
 
-    @private_attributes.setter
-    def private_attributes(self, private_attributes):
-        """Sets the private_attributes of this Link.
+    @private.setter
+    def private(self, private):
+        """Sets the private attributes of this Link.
 
 
-        :param private_attributes: The private_attributes of this Link.
-        :type private_attributes: List[str]
+        :param private: The private attributes of this Link.
+        :type private: List[str]
         """
 
-        self._private_attributes = private_attributes
+        self._private = private
 
     @property
     def timestamp(self):

--- a/sdx_lc/models/node.py
+++ b/sdx_lc/models/node.py
@@ -24,7 +24,6 @@ class Node(Model):
         short_name=None,
         location=None,
         ports=None,
-        private_attributes=None,
     ):  # noqa: E501
         """Node - a model defined in Swagger
 
@@ -38,8 +37,6 @@ class Node(Model):
         :type location: Location
         :param ports: The ports of this Node.  # noqa: E501
         :type ports: List[Port]
-        :param private_attributes: The private_attributes of this Node.  # noqa: E501
-        :type private_attributes: List[str]
         """
         self.swagger_types = {
             "id": str,
@@ -47,7 +44,6 @@ class Node(Model):
             "short_name": str,
             "location": Location,
             "ports": List[Port],
-            "private_attributes": List[str],
         }
 
         self.attribute_map = {
@@ -56,14 +52,12 @@ class Node(Model):
             "short_name": "short_name",
             "location": "location",
             "ports": "ports",
-            "private_attributes": "private_attributes",
         }
         self._id = id
         self._name = name
         self._short_name = short_name
         self._location = location
         self._ports = ports
-        self._private_attributes = private_attributes
 
     @classmethod
     def from_dict(cls, dikt):
@@ -194,24 +188,3 @@ class Node(Model):
             )  # noqa: E501
 
         self._ports = ports
-
-    @property
-    def private_attributes(self):
-        """Gets the private_attributes of this Node.
-
-
-        :return: The private_attributes of this Node.
-        :rtype: List[str]
-        """
-        return self._private_attributes
-
-    @private_attributes.setter
-    def private_attributes(self, private_attributes):
-        """Sets the private_attributes of this Node.
-
-
-        :param private_attributes: The private_attributes of this Node.
-        :type private_attributes: List[str]
-        """
-
-        self._private_attributes = private_attributes

--- a/sdx_lc/models/port.py
+++ b/sdx_lc/models/port.py
@@ -26,6 +26,8 @@ class Port(Model):
         status=None,
         state=None,
         nni=None,
+        type=None,
+        mtu=None,
         services=None,
         private_attributes=None,
     ):  # noqa: E501
@@ -47,6 +49,10 @@ class Port(Model):
         :type state: str
         :param nni: The nni of this Port.  # noqa: E501
         :type nni: str
+        :param type: Technology and bandwidth of this physical Port.  # noqa: E501
+        :type type: str
+        :param mtu: The Maximum Transmission Unit of this Port.  # noqa: E501
+        :type mtu: int
         :param services: The services of this Port.  # noqa: E501
         :type services: Service
         :param private_attributes: The private_attributes of this Port.  # noqa: E501
@@ -61,6 +67,8 @@ class Port(Model):
             "status": str,
             "state": str,
             "nni": str,
+            "type": str,
+            "mtu": int,
             "services": Service,
             "private_attributes": List[str],
         }
@@ -74,6 +82,8 @@ class Port(Model):
             "status": "status",
             "state": "state",
             "nni": "nni",
+            "type": "type",
+            "mtu": "mtu",
             "services": "services",
             "private_attributes": "private_attributes",
         }
@@ -85,6 +95,8 @@ class Port(Model):
         self._status = status
         self._state = state
         self._nni = nni
+        self._type = type
+        self._mtu = mtu
         self._services = services
         self._private_attributes = private_attributes
 
@@ -280,6 +292,48 @@ class Port(Model):
         """
 
         self._nni = nni
+
+    @property
+    def type(self):
+        """Gets the type of this Port.
+
+
+        :return: The type of this Port.
+        :type: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """Sets the type of this Port.
+
+
+        :param type: The type of this Port.
+        :type type: str
+        """
+
+        self._type = type
+
+    @property
+    def mtu(self):
+        """Gets the mtu of this Port.
+
+
+        :return: The mtu of this Port.
+        :type: int
+        """
+        return self._mtu
+
+    @mtu.setter
+    def mtu(self, mtu):
+        """Sets the mtu of this Port.
+
+
+        :param mtu: The mtu of this Port.
+        :type mtu: int
+        """
+
+        self._mtu = mtu
 
     @property
     def services(self):

--- a/sdx_lc/models/port.py
+++ b/sdx_lc/models/port.py
@@ -55,7 +55,7 @@ class Port(Model):
         :type mtu: int
         :param services: The services of this Port.  # noqa: E501
         :type services: Service
-        :param private: The private of this Port.  # noqa: E501
+        :param private: The private attributes of this Port.  # noqa: E501
         :type private: List[str]
         """
         self.swagger_types = {

--- a/sdx_lc/models/port.py
+++ b/sdx_lc/models/port.py
@@ -29,7 +29,7 @@ class Port(Model):
         type=None,
         mtu=None,
         services=None,
-        private_attributes=None,
+        private=None,
     ):  # noqa: E501
         """Port - a model defined in Swagger
 
@@ -55,8 +55,8 @@ class Port(Model):
         :type mtu: int
         :param services: The services of this Port.  # noqa: E501
         :type services: Service
-        :param private_attributes: The private_attributes of this Port.  # noqa: E501
-        :type private_attributes: List[str]
+        :param private: The private of this Port.  # noqa: E501
+        :type private: List[str]
         """
         self.swagger_types = {
             "id": str,
@@ -70,7 +70,7 @@ class Port(Model):
             "type": str,
             "mtu": int,
             "services": Service,
-            "private_attributes": List[str],
+            "private": List[str],
         }
 
         self.attribute_map = {
@@ -85,7 +85,7 @@ class Port(Model):
             "type": "type",
             "mtu": "mtu",
             "services": "services",
-            "private_attributes": "private_attributes",
+            "private": "private",
         }
         self._id = id
         self._name = name
@@ -98,7 +98,7 @@ class Port(Model):
         self._type = type
         self._mtu = mtu
         self._services = services
-        self._private_attributes = private_attributes
+        self._private = private
 
     @classmethod
     def from_dict(cls, dikt):
@@ -357,22 +357,22 @@ class Port(Model):
         self._services = services
 
     @property
-    def private_attributes(self):
-        """Gets the private_attributes of this Port.
+    def private(self):
+        """Gets the private of this Port.
 
 
-        :return: The private_attributes of this Port.
+        :return: The private of this Port.
         :rtype: List[str]
         """
-        return self._private_attributes
+        return self._private
 
-    @private_attributes.setter
-    def private_attributes(self, private_attributes):
-        """Sets the private_attributes of this Port.
+    @private.setter
+    def private(self, private):
+        """Sets the private of this Port.
 
 
-        :param private_attributes: The private_attributes of this Port.
-        :type private_attributes: List[str]
+        :param private: The private of this Port.
+        :type private: List[str]
         """
 
-        self._private_attributes = private_attributes
+        self._private = private

--- a/sdx_lc/swagger/swagger.yaml
+++ b/sdx_lc/swagger/swagger.yaml
@@ -762,9 +762,9 @@ components:
         name:
           type: string
         ingress_port:
-          $ref: '#/components/schemas/port'
+          $ref: '#/components/schemas/connection_port'
         egress_port:
-          $ref: '#/components/schemas/port'
+          $ref: '#/components/schemas/connection_port'
         quantity:
           type: integer
           format: int32
@@ -865,6 +865,57 @@ components:
           status: up
       xml:
         name: Connection
+    connection_port:
+      required:
+      - id
+      - name
+      - node
+      - status
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+          example: urn:sdx:port:amlight.net:Novi06:9
+        short_name:
+          type: string
+          example: "9"
+        node:
+          type: string
+          example: urn:sdx:port:amlight.net:Novi06
+        label_range:
+          type: array
+          items:
+            type: string
+        status:
+          type: string
+          example: up
+        state:
+          type: string
+          example: enabled
+        nni:
+          type: string
+          example: urn:sdx:link:amlight.net:Novi03/2_s3/s3-eth2
+        services:
+          $ref: '#/components/schemas/service'
+        private_attributes:
+          type: array
+          items:
+            type: string
+      example:
+        node: urn:sdx:port:amlight.net:Novi06
+        name: urn:sdx:port:amlight.net:Novi06:9
+        short_name: "9"
+        id: id
+        status: up
+        services:
+          l2vpn-ptp:
+            vlan_range:
+            - 1000
+            - 2000
+      xml:
+        name: port
     User:
       type: object
       properties:

--- a/sdx_lc/swagger/swagger.yaml
+++ b/sdx_lc/swagger/swagger.yaml
@@ -665,6 +665,7 @@ components:
             properties:
               port_id:
                 type: string
+                pattern: '^urn:sdx:port:[A-Za-z0-9_,./-]*:[A-Za-z0-9_.,/-]*:[A-Za-z0-9_.,/-]*$'
               vlan:
                 type: string
         description:
@@ -905,151 +906,40 @@ components:
       - nodes
       - timestamp
       - version
+      - model_version
       type: object
+      additionalProperties: false
       properties:
         id:
           type: string
+          pattern: '^urn:sdx:topology:[A-Za-z0-9_.:-]*$'
         name:
           type: string
-          example: amLight
+          maxLength: 30
+          pattern: '^[A-Za-z0-9_,./-]*$'
         services:
-          $ref: '#/components/schemas/service'
+          type: array
+          items:
+            type: string
+            enum: ['l2vpn-ptp', 'l2vpn-ptmp']
         version:
           type: integer
           format: int64
-          example: 1
         model_version:
           type: string
-          example: 2.0.0
+          default: 2.0.0
         timestamp:
           type: string
-          format: date-time
+          pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$'
         nodes:
           type: array
+          minItems: 1
           items:
             $ref: '#/components/schemas/node'
         links:
           type: array
           items:
             $ref: '#/components/schemas/link'
-        private_attributes:
-          type: array
-          items:
-            type: string
-      example:
-        nodes:
-        - name: urn:sdx:node:amlight.net:Novi06
-          short_name: Novi06
-          id: id
-          location:
-            address: Miami
-            latitude: -28.51107891831147
-            longitude: -79.57947854792273
-            iso3166_2_lvl4: iso3166_2_lvl4
-          ports:
-          - node: urn:sdx:port:amlight.net:Novi06
-            name: urn:sdx:port:amlight.net:Novi06:9
-            short_name: "9"
-            id: id
-            status: up
-            services:
-              l2vpn-ptp:
-                vlan_range:
-                - 1000
-                - 1500
-          - node: urn:sdx:port:amlight.net:Novi06
-            name: urn:sdx:port:amlight.net:Novi06:9
-            short_name: "9"
-            id: id
-            status: up
-            services:
-              l2vpn-ptp:
-                vlan_range:
-                - - 1000
-                  - 2000
-                - - 3000
-                  - 4000
-        - name: urn:sdx:node:amlight.net:Novi06
-          short_name: Novi06
-          id: id
-          location:
-            address: Miami
-            latitude: -28.51107891831147
-            longitude: -79.57947854792273
-            iso3166_2_lvl4: iso3166_2_lvl4
-          ports:
-          - node: urn:sdx:port:amlight.net:Novi06
-            name: urn:sdx:port:amlight.net:Novi06:9
-            label_range:
-            - label_range
-            - label_range
-            short_name: "9"
-            id: id
-            status: up
-          - node: urn:sdx:port:amlight.net:Novi06
-            name: urn:sdx:port:amlight.net:Novi06:9
-            label_range:
-            - label_range
-            - label_range
-            short_name: "9"
-            id: id
-            status: up
-        timestamp: 2000-01-23T04:56:07.000Z
-        name: amLight
-        links:
-        - bandwidth: 80083.7389632821
-          packet_loss: 59.621339166831824
-          latency: 146582.15146899645
-          name: miami-Boca.amLight.sdx
-          residual_bandwidth: 602746.015561422
-          short_name: Miami-BocaRaton
-          id: id
-          availability: 56.37376656633328
-          ports:
-          - node: urn:sdx:port:amlight.net:Novi06
-            name: urn:sdx:port:amlight.net:Novi06:9
-            label_range:
-            - label_range
-            - label_range
-            short_name: "9"
-            id: id
-            status: up
-          - node: urn:sdx:port:amlight.net:Novi06
-            name: urn:sdx:port:amlight.net:Novi06:10
-            label_range:
-            - label_range
-            - label_range
-            short_name: "10"
-            id: id
-            status: up
-        - bandwidth: 80083.7389632821
-          packet_loss: 59.621339166831824
-          latency: 146582.15146899645
-          name: miami-Boca.amLight.sdx
-          residual_bandwidth: 602746.015561422
-          short_name: Miami-BocaRaton
-          id: id
-          availability: 56.37376656633328
-          ports:
-          - node: urn:sdx:port:amlight.net:Novi06
-            name: urn:sdx:port:amlight.net:Novi06:9
-            label_range:
-            - label_range
-            - label_range
-            short_name: "9"
-            id: id
-            status: up
-          - node: urn:sdx:port:amlight.net:Novi06
-            name: urn:sdx:port:amlight.net:Novi06:10
-            label_range:
-            - label_range
-            - label_range
-            short_name: "10"
-            id: id
-            status: up
-        id: id
-        version: 1
-        model_version: 2.0.0
       xml:
         name: topology
     node:
@@ -1059,51 +949,27 @@ components:
       - name
       - ports
       type: object
+      additionalProperties: false
       properties:
         id:
           type: string
+          pattern: '^urn:sdx:node:[A-Za-z0-9_,./-]*:[A-Za-z0-9.,_/-]*$'
         name:
           type: string
-          example: urn:sdx:node:amlight.net:Novi06
-        short_name:
-          type: string
-          example: Novi06
+          maxLength: 30
+          pattern: '^[A-Za-z0-9.,_/-]*$'
         location:
           $ref: '#/components/schemas/location'
         ports:
           type: array
           items:
             $ref: '#/components/schemas/port'
-        private_attributes:
-          type: array
-          items:
-            type: string
-      example:
-        name: urn:sdx:node:amlight.net:Novi06
-        short_name: Novi06
-        id: id
-        location:
-          address: Miami
-          latitude: -28.51107891831147
-          longitude: -79.57947854792273
-          iso3166_2_lvl4: iso3166_2_lvl4
-        ports:
-        - node: urn:sdx:port:amlight.net:Novi06
-          name: urn:sdx:port:amlight.net:Novi06:9
-          label_range:
-          - label_range
-          - label_range
-          short_name: "9"
-          id: id
-          status: up
-        - node: urn:sdx:port:amlight.net:Novi06
-          name: urn:sdx:port:amlight.net:Novi06:10
-          label_range:
-          - label_range
-          - label_range
-          short_name: "10"
-          id: id
-          status: up
+        status:
+          type: string
+          enum: ['up', 'down', 'error']
+        state:
+          type: string
+          enum: ['enabled', 'disabled', 'maintenance']
       xml:
         name: node
     link:
@@ -1111,75 +977,63 @@ components:
       - id
       - name
       - ports
+      - bandwidth
+      - status
+      - state
       type: object
+      additionalProperties: false
       properties:
         id:
           type: string
+          pattern: '^urn:sdx:link:[A-Za-z0-9_,./-]*:[A-Za-z0-9_.,/-]*$'
         name:
           type: string
-          example: miami-Boca.amLight.sdx
-        short_name:
-          type: string
-          example: Miami-BocaRaton
+          maxLength: 30
+          pattern: '^[A-Za-z0-9_.,/-]*$'
         ports:
           type: array
+          minItems: 2
+          maxItems: 2
           items:
-            $ref: '#/components/schemas/port'
+            type: string
+            pattern: '^urn:sdx:port:[A-Za-z0-9_,./-]*:[A-Za-z0-9_.,/-]*:[A-Za-z0-9_.,/-]*$'
+        type:
+          type: string
+          enum: ['intra']
         bandwidth:
-          maximum: 1000000
-          minimum: 1
           type: number
+          format: float
+          minimum: 0
         residual_bandwidth:
-          maximum: 1000000
-          minimum: 1
           type: number
+          format: float
+          minimum: 0
+          maximum: 100
         latency:
-          maximum: 1000000
-          minimum: 1
           type: number
+          format: float
+          minimum: 0
         packet_loss:
+          type: number
+          format: float
           maximum: 100
           minimum: 0
-          type: number
         availability:
+          type: number
+          format: float
           maximum: 100
           minimum: 0
-          type: number
         status:
           type: string
-          example: up
+          enum: ['up','down','error']
         state:
           type: string
-          example: enabled
-        private_attributes:
+          enum: ['enabled','disabled','maintenance']
+        private:
           type: array
           items:
             type: string
-        timestamp:
-          type: string
-          format: date-time
-        measurement_period:
-          $ref: '#/components/schemas/link_measurement_period'
-      example:
-        bandwidth: 80083.7389632821
-        packet_loss: 59.621339166831824
-        latency: 146582.15146899645
-        name: miami-Boca.amLight.sdx
-        residual_bandwidth: 602746.015561422
-        short_name: Miami-BocaRaton
-        id: id
-        availability: 56.37376656633328
-        ports:
-        - node: urn:sdx:port:amlight.net:Novi06
-          name: urn:sdx:port:amlight.net:Novi06:9
-          short_name: "9"
-          id: id
-          status: up
-        - node: urn:sdx:port:amlight.net:Novi06
-          name: urn:sdx:port:amlight.net:Novi06:10
-          short_name: "10"
-          id: id
-          status: up
+            enum: ['residual_bandwidth', 'latency', 'packet_loss']
       xml:
         name: link
     port:
@@ -1187,50 +1041,46 @@ components:
       - id
       - name
       - node
+      - type
       - status
+      - state
       type: object
+      additionalProperties: false
       properties:
         id:
           type: string
+          pattern: '^urn:sdx:port:[A-Za-z0-9_,./-]*:[A-Za-z0-9_.,/-]*:[A-Za-z0-9_.,/-]*$'
         name:
           type: string
-          example: urn:sdx:port:amlight.net:Novi06:9
-        short_name:
-          type: string
-          example: "9"
+          maxLength: 30
+          pattern: '^[A-Za-z0-9_.,/-]*$'
         node:
           type: string
-          example: urn:sdx:port:amlight.net:Novi06
-        label_range:
-          type: array
-          items:
-            type: string
-        status:
+          pattern: '^urn:sdx:node:[A-Za-z0-9_.,/-]*:[A-Za-z0-9_.,/-]*$'
+        type:
           type: string
-          example: up
-        state:
-          type: string
-          example: enabled
+          enum: ['100FE','1GE','10GE','25GE','40GE','50GE','100GE','400GE','Other']
+        mtu:
+          type: integer
+          format: int32
+          minimum: 1500
+          maximum: 10000
+          default: 1500
         nni:
           type: string
-          example: urn:sdx:link:amlight.net:Novi03/2_s3/s3-eth2
+          pattern: '^(urn:sdx:(port:[A-Za-z0-9_,./-]*|link):[A-Za-z0-9_.,/-]*:[A-Za-z0-9_.,/-]*)?$'
+        status:
+          type: string
+          enum: ['up', 'down', 'error']
+        state:
+          type: string
+          enum: ['enabled', 'disabled', 'maintenance']
         services:
           $ref: '#/components/schemas/service'
         private_attributes:
           type: array
           items:
             type: string
-      example:
-        node: urn:sdx:port:amlight.net:Novi06
-        name: urn:sdx:port:amlight.net:Novi06:9
-        short_name: "9"
-        id: id
-        status: up
-        services:
-          l2vpn-ptp:
-            vlan_range:
-            - 1000
-            - 2000
       xml:
         name: port
     ApiResponse:
@@ -1249,46 +1099,60 @@ components:
         message: message
     location:
       type: object
+      required:
+        - address
+        - latitude
+        - longitude
+        - iso3166_2_lvl4
       properties:
         address:
           type: string
+          maxLength: 255
         latitude:
           type: number
+          minimum: -90.0
+          maximum: 90.0
         longitude:
           type: number
+          minimum: -90.0
+          maximum: 90.0
         iso3166_2_lvl4:
           type: string
+          minLength: 5
+          maxLength: 5
+          pattern: '^[A-Z]{2}-[a-zA-Z0-9]{1,3}$'
+        private:
+          type: array
+          items:
+            type: string
+            enum: ['address', 'latitude', 'longitude', 'iso3166_2_lvl4']
+      additionalProperties: false
     service:
       type: object
       properties:
         l2vpn-ptp:
           type: object
+          properties:
+            vlan_range:
+              type: array
+              items:
+                type: array
+                items:
+                  type: integer
+                minItems: 2
+                maxItems: 2
         l2vpn-ptmp:
           type: object
-        monitoring_capability:
-          type: string
-        owner:
-          type: string
-        private_attributes:
-          type: array
-          items:
-            type: string
-        provisioning_system:
-          type: string
-        provisioning_url:
-          type: string
-        vendor:
-          type: array
-          items:
-            type: string
+          properties:
+            vlan_range:
+              type: array
+              items:
+                type: array
+                items:
+                  type: integer
+                minItems: 2
+                maxItems: 2
       description: Domain Services
-    link_measurement_period:
-      type: object
-      properties:
-        period:
-          type: number
-        time_unit:
-          type: string
     connection_scheduling:
       type: object
       properties:

--- a/sdx_lc/test/test_connection_controller.py
+++ b/sdx_lc/test/test_connection_controller.py
@@ -49,7 +49,6 @@ class TestConnectionController(BaseTestCase):
             label_range=None,
             status="unknown",
             state="unknown",
-            private_attributes=None,
         )
 
         egress_port = Port(
@@ -59,7 +58,6 @@ class TestConnectionController(BaseTestCase):
             label_range=None,
             status="unknown",
             state="unknown",
-            private_attributes=None,
         )
 
         body = Connection(

--- a/sdx_lc/test/test_link_controller.py
+++ b/sdx_lc/test/test_link_controller.py
@@ -20,19 +20,19 @@ class TestLinkController(BaseTestCase):
         add a new link to the topology
         """
         body = Link(
-            id="test_add_link_id",
+            id="urn:sdx:link:test.net:test_add_link_name",
             name="test_add_link_name",
-            short_name="test_add_link_short_name",
-            ports=list(),
+            ports=[
+                "urn:sdx:port:test.net:test1:1",
+                "urn:sdx:port:test.net:test2:2",
+            ],
             bandwidth=1.0,
             residual_bandwidth=1.0,
             latency=1.0,
             packet_loss=0.0,
             availability=0.0,
-            status="unknown",
-            state="unknown",
-            private_attributes=list(),
-            timestamp=datetime.datetime.fromtimestamp(0),
+            status="up",
+            state="enabled",
             measurement_period=None,
         )
         response = self.client.open(
@@ -72,19 +72,19 @@ class TestLinkController(BaseTestCase):
         Update an existing link
         """
         body = Link(
-            id="test_update_link_id",
+            id="urn:sdx:link:test.net:test_update_link_name",
             name="test_update_link_name",
-            short_name="test_update_link_short_name",
-            ports=list(),
+            ports=[
+                "urn:sdx:port:test.net:test1:1",
+                "urn:sdx:port:test.net:test2:2",
+            ],
             bandwidth=1.0,
             residual_bandwidth=1.0,
             latency=1.0,
             packet_loss=0.0,
             availability=0.0,
-            status="unknown",
-            state="unknown",
-            private_attributes=list(),
-            timestamp=datetime.datetime.fromtimestamp(0),
+            status="down",
+            state="enabled",
             measurement_period=None,
         )
         response = self.client.open(

--- a/sdx_lc/test/test_link_controller.py
+++ b/sdx_lc/test/test_link_controller.py
@@ -85,6 +85,7 @@ class TestLinkController(BaseTestCase):
             availability=0.0,
             status="down",
             state="enabled",
+            private=list(),
             measurement_period=None,
         )
         response = self.client.open(

--- a/sdx_lc/test/test_node_controller.py
+++ b/sdx_lc/test/test_node_controller.py
@@ -29,6 +29,7 @@ class TestNodeController(BaseTestCase):
             status="up",
             state="enabled",
             type="100GE",
+            private=None,
         )
     ]
 

--- a/sdx_lc/test/test_node_controller.py
+++ b/sdx_lc/test/test_node_controller.py
@@ -18,28 +18,25 @@ class TestNodeController(BaseTestCase):
         address="unknown",
         latitude=0.0,
         longitude=0.0,
+        iso3166_2_lvl4="US-FL",
     )
 
     __ports = [
         Port(
-            id="test_node_port_id",
+            id="urn:sdx:port:test.net:test1:1",
             name="test_node_port_name",
-            short_name="test_node_port_short_name",
-            node="test_node_id",
-            label_range=None,
-            status="unknown",
-            state="unknown",
-            private_attributes=None,
+            node="urn:sdx:node:test.net:test1",
+            status="up",
+            state="enabled",
+            type="100GE",
         )
     ]
 
     __node = Node(
-        id="test_node_id",
+        id="urn:sdx:node:test.net:test1",
         name="test_node_name",
-        short_name="test_node_short_name",
         location=__location,
         ports=__ports,
-        private_attributes=None,
     )
 
     def test_add_node(self):
@@ -87,6 +84,7 @@ class TestNodeController(BaseTestCase):
             address="unknown",
             latitude=0.0,
             longitude=0.0,
+            iso3166_2_lvl4="US-FL",
         )
         response = self.client.open(
             "/SDX-LC/2.0.0/node",

--- a/sdx_lc/test/test_topology_controller.py
+++ b/sdx_lc/test/test_topology_controller.py
@@ -23,54 +23,84 @@ class TestTopologyController(BaseTestCase):
         address="unknown",
         latitude=0.0,
         longitude=0.0,
+        iso3166_2_lvl4="US-FL",
     )
 
     __ports = [
         Port(
-            id="test_topology_port_id",
+            id="urn:sdx:port:example.net:test1:1",
             name="test_topology_port_name",
-            short_name="test_topology_port_short_name",
-            node="test_topology_id",
-            label_range=None,
-            status="unknown",
-            state="unknown",
-            private_attributes=None,
-        )
+            node="urn:sdx:node:example.net:test1",
+            nni="urn:sdx:link:example.net:test1/1_test1/2",
+            status="up",
+            state="enabled",
+            type="100GE",
+            mtu=9000,
+        ),
+        Port(
+            id="urn:sdx:port:example.net:test1:2",
+            name="test_topology_port_name2",
+            node="urn:sdx:node:example.net:test1",
+            nni="urn:sdx:link:example.net:test1/1_test1/2",
+            status="up",
+            state="enabled",
+            type="100GE",
+            mtu=9000,
+        ),
+        Port(
+            id="urn:sdx:port:example.net:test1:3",
+            name="test_topology_port_name3",
+            node="urn:sdx:node:example.net:test1",
+            nni="",
+            status="up",
+            state="enabled",
+            type="100GE",
+            mtu=9000,
+        ),
+        Port(
+            id="urn:sdx:port:example.net:test1:4",
+            name="test_topology_port_name4",
+            node="urn:sdx:node:example.net:test1",
+            nni="urn:sdx:port:otheroxp.net:other_sw:99",
+            status="up",
+            state="enabled",
+            type="100GE",
+            mtu=9000,
+        ),
     ]
 
     __nodes = [
         Node(
-            id="test_topology_node_id",
+            id="urn:sdx:node:example.net:test1",
             name="test_topology_node_name",
-            short_name="test_topology_node_short_name",
             location=__location,
             ports=__ports,
-            private_attributes=None,
         )
     ]
 
     __links = [
         Link(
-            id="test_topology_link_id",
+            id="urn:sdx:link:example.net:test1/1_test1/2",
             name="test_topology_link_name",
-            short_name="test_topology_link_short_name",
-            ports=list(),
+            ports=[
+                "urn:sdx:port:example.net:test1:1",
+                "urn:sdx:port:example.net:test1:2",
+            ],
             bandwidth=1.0,
             residual_bandwidth=1.0,
             latency=1.0,
             packet_loss=0.0,
             availability=0.0,
-            status="unknown",
-            state="unknown",
-            private_attributes=list(),
-            timestamp=datetime.datetime.fromtimestamp(0),
+            status="error",
+            state="maintenance",
             measurement_period=None,
         )
     ]
 
     __topology = Topology(
-        id="test:topology:example.net",
+        id="urn:sdx:topology:example.net",
         name="test_topology_name",
+        model_version="2.0.0",
         services=None,
         version=0,
         timestamp=datetime.datetime.fromtimestamp(0),


### PR DESCRIPTION
Fix #157 

### Description of the change

- Changed attributes on the swagger/openapi yaml file to comply with Topology Data Model spec 2.0.0
- Removed examples from the swagger spec (easy to maintain)
- port model updated to add new fields (mtu and type)
- updated unit tests to adjust for the new openapi definition.
- renamed `private_attributes` to `private` (removed from Node, which does not have any attribute allowed to be private)
