### PR TITLE
Add error handling for connection reset when pulling the topology and the OXP is still booting up

### DIFF
--- a/sdx_lc/jobs/pull_topo_changes.py
+++ b/sdx_lc/jobs/pull_topo_changes.py
@@ -50,7 +50,7 @@ def process_domain_controller_topo(db_instance):
 
         try:
             pulled_topology = urllib.request.urlopen(OXP_PULL_URL).read()
-        except urllib.request.URLError:
+        except (urllib.request.URLError, ConnectionResetError):
             logger.debug("Error connecting to domain controller...")
             time.sleep(int(OXP_PULL_INTERVAL))
             continue


### PR DESCRIPTION
Fix #144 

### Description of the change

This change adds a minimal enhancement on the error handling process while pulling the topology from OXP and the OXP is not accessible (e.g., OXP is still booting up or during a maintenance window) -- resulting in ConnectionReset (not previously handled).

Local tests following the [guidelines for single server deployment](https://sdx-docs.readthedocs.io/en/latest/sdx_deploy_single_server.html) showed this fix was effective to avoid exceptions and crash of the topology pulling script. 