### PR TITLE
Rename private_attributes -> private on swagger

### DIFF
--- a/sdx_lc/swagger/swagger.yaml
+++ b/sdx_lc/swagger/swagger.yaml
@@ -1128,7 +1128,7 @@ components:
           enum: ['enabled', 'disabled', 'maintenance']
         services:
           $ref: '#/components/schemas/service'
-        private_attributes:
+        private:
           type: array
           items:
             type: string


### PR DESCRIPTION
Rename Topology.Node.Port.private_attributes to private, which was left behind.