### PR TITLE
Housekeeping updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
 
     steps:
       - name: Check out code

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Cong Wang <cwang@renci.org> <cwang@aw-sdx-lc-1.renci.org>
+Cong Wang <cwang@renci.org> <cong@Cs-MacBook-Air.attlocal.net>
+Cong Wang <cwang@renci.org> <cwang@rciadmins-MBP.attlocal.net>
+Italo Valcy <italo@ampath.net> <italovalcy@gmail.com>
+Sajith Sasidharan <sajith@hcoop.net> <sajith@renci.org>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,11 @@
 [build-system]
-requires = [
-    "setuptools >= 61.0",
-]
-build-backend = "setuptools.build_meta"
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "sdx-lc"
+version = "3.0.0.dev0"
 description = "AtlanticWave-SDX project's local controller"
-version = "2.0.0"
 authors = [
     { name = "Yufeng Xin", email = "yxin@renci.org" },
     { name = "Cong Wang", email = "cwang@renci.org" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
     { name = "Yufeng Xin", email = "yxin@renci.org" },
     { name = "Cong Wang", email = "cwang@renci.org" },
     { name = "Sajith Sasidharan", email = "sajith@renci.org" },
+    { name = "Italo Valcy", email = "italo@ampath.net" },    
 ]
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name = "Italo Valcy", email = "italo@ampath.net" },    
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Similar to https://github.com/atlanticwave-sdx/sdx-controller/pull/321:

- Use flit as the build backend.
- Bump version up to `3.0.0.dev0`.
- Require Python >= 3.9.
- Remove Python 3.8 from the test matrix, and add Python 3.11 and 3.12 instead.
- Add Italo to author's list.
- Add a `.mailmap`.

This time I did a smoke test with `docker compose up --build`. :-)