### PR TITLE
Change sleep call to be executed at the begin of pull topology routine

### DIFF
--- a/sdx_lc/jobs/pull_topo_changes.py
+++ b/sdx_lc/jobs/pull_topo_changes.py
@@ -29,6 +29,7 @@ def main():
 
 def process_domain_controller_topo(db_instance):
     while True:
+        time.sleep(int(OXP_PULL_INTERVAL))
         latest_topology_exists = False
         latest_topology = db_instance.read_from_db("latest_topology")
 
@@ -52,11 +53,9 @@ def process_domain_controller_topo(db_instance):
             pulled_topology = urllib.request.urlopen(OXP_PULL_URL).read()
         except (urllib.request.URLError, ConnectionResetError):
             logger.debug("Error connecting to domain controller...")
-            time.sleep(int(OXP_PULL_INTERVAL))
             continue
 
         if not pulled_topology:
-            time.sleep(int(OXP_PULL_INTERVAL))
             continue
 
         logger.debug("Pulled request from domain controller")
@@ -89,8 +88,6 @@ def process_domain_controller_topo(db_instance):
         response = rpc_producer.call(json.dumps(json_pulled_topology))
         # Signal to end keep alive pings.
         rpc_producer.stop()
-
-        time.sleep(int(OXP_PULL_INTERVAL))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix #166 

### Description of the change

As described on Issue #166, there was conditions where the pull topology routine were being executing in a loop, one request after the other very massively, and possibility impacting the OXP. With the proposed change, the sleep interval will happen at the being of the pull topology routine, so any failure when fetching the topology from OXP will then have a interval before next request (as already defined in OXP_PULL_INTERVAL env var)