### PR TITLE
Change pymongo logging to INFO level

### DIFF
--- a/sdx_lc/utils/db_utils.py
+++ b/sdx_lc/utils/db_utils.py
@@ -4,6 +4,9 @@ from urllib.parse import urlparse
 
 import pymongo
 
+pymongo_logger = logging.getLogger("pymongo")
+pymongo_logger.setLevel(logging.INFO)
+
 
 def obfuscate_password_in_uri(uri: str) -> str:
     """


### PR DESCRIPTION
Setting pymongo to INFO level, so we don't get noisy debug messages from pymongo when we use DEBUG level logging for LC.