### PR TITLE
Add topo timestamp api

### DIFF
--- a/sdx_lc/controllers/topology_controller.py
+++ b/sdx_lc/controllers/topology_controller.py
@@ -116,6 +116,9 @@ def get_topology():  # noqa: E501
     """
     return "do some magic!"
 
+def get_topology_timestamp():  # noqa: E501
+    """get timestamp of latest topology pulling from OXP"""
+    return "do some magic!"
 
 def get_topologyby_version(topology_id, version):  # noqa: E501
     """Find topology by version

--- a/sdx_lc/controllers/topology_controller.py
+++ b/sdx_lc/controllers/topology_controller.py
@@ -118,7 +118,10 @@ def get_topology():  # noqa: E501
 
 def get_topology_timestamp():  # noqa: E501
     """get timestamp of latest topology pulling from OXP"""
-    return "do some magic!"
+    latest_topology_ts = db_instance.read_from_db("latest_topology_ts")
+    if not latest_topology_ts:
+        return "No topology was pulled from OXP yet", 404
+    return latest_topology_ts["latest_topology_ts"]
 
 def get_topologyby_version(topology_id, version):  # noqa: E501
     """Find topology by version

--- a/sdx_lc/controllers/topology_controller.py
+++ b/sdx_lc/controllers/topology_controller.py
@@ -116,12 +116,14 @@ def get_topology():  # noqa: E501
     """
     return "do some magic!"
 
+
 def get_topology_timestamp():  # noqa: E501
     """get timestamp of latest topology pulling from OXP"""
     latest_topology_ts = db_instance.read_from_db("latest_topology_ts")
     if not latest_topology_ts:
         return "No topology was pulled from OXP yet", 404
     return latest_topology_ts["latest_topology_ts"]
+
 
 def get_topologyby_version(topology_id, version):  # noqa: E501
     """Find topology by version

--- a/sdx_lc/jobs/pull_topo_changes.py
+++ b/sdx_lc/jobs/pull_topo_changes.py
@@ -1,9 +1,7 @@
-import argparse
 import json
 import logging
 import os.path
 import sys
-import threading
 import time
 import urllib.request
 
@@ -82,6 +80,8 @@ def process_domain_controller_topo(db_instance):
             f"topoVersion{json_pulled_topology['version']}", pulled_topology
         )
         db_instance.add_key_value_pair_to_db("latest_topology", pulled_topology)
+        topology_ts = int(time.time())
+        db_instance.add_key_value_pair_to_db("latest_topology_ts", str(topology_ts))
         logger.debug("Added pulled topo to db")
         # initiate rpc producer with 5 seconds timeout
         rpc_producer = RpcProducer(5, "", "topo")

--- a/sdx_lc/swagger/swagger.yaml
+++ b/sdx_lc/swagger/swagger.yaml
@@ -119,6 +119,24 @@ paths:
         "404":
           description: topology not found
       x-openapi-router-controller: sdx_lc.controllers.topology_controller
+  /topology/time:
+    get:
+      tags:
+      - topology
+      summary: get timestamp of latest topology pulling from OXP
+      description: ID of the topology
+      operationId: get_topology_timestamp
+      responses:
+        "200":
+          description: ok
+          content:
+            text/plain:
+              schema:
+                type: string
+                x-content-type: text/plain
+        "404":
+          description: Topology timestamp not found
+      x-openapi-router-controller: sdx_lc.controllers.topology_controller
   /topology/version:
     get:
       tags:


### PR DESCRIPTION
Add an API to query the timestamp for latest topology pulling from OXP.
When updating the latest topology, LC will save the timestamp to the db. The timestamp is in seconds, e.g., 1734837838.