### PR TITLE
Propagate oxp response to sdx controller

### DIFF
--- a/sdx_lc/controllers/topology_controller.py
+++ b/sdx_lc/controllers/topology_controller.py
@@ -66,7 +66,7 @@ def add_topology(body):  # noqa: E501
     logger.debug("Publishing Message to MQ: {}".format(body))
 
     # initiate rpc producer with 5 seconds timeout
-    rpc = RpcProducer(5, "", "topo")
+    rpc = RpcProducer(5, "", "oxp_update")
     response = rpc.call(json_body)
     # Signal to end keep alive pings.
     rpc.stop()

--- a/sdx_lc/handlers/sdx_controller_msg_handler.py
+++ b/sdx_lc/handlers/sdx_controller_msg_handler.py
@@ -1,10 +1,11 @@
 import json
 import logging
-import requests
 import os
 
-from sdx_lc.utils.db_utils import DbUtils
+import requests
+
 from sdx_lc.messaging.rpc_queue_producer import RpcProducer
+from sdx_lc.utils.db_utils import DbUtils
 
 logger = logging.getLogger(__name__)
 

--- a/sdx_lc/handlers/sdx_controller_msg_handler.py
+++ b/sdx_lc/handlers/sdx_controller_msg_handler.py
@@ -3,6 +3,8 @@ import logging
 import requests
 import os
 
+from sdx_lc.utils.db_utils import DbUtils
+
 logger = logging.getLogger(__name__)
 
 OXP_CONNECTION_URL = os.environ.get("OXP_CONNECTION_URL")
@@ -17,8 +19,13 @@ def is_json(myjson):
 
 
 class SdxControllerMsgHandler:
-    def __init__(self, db_instance):
-        self.db_instance = db_instance
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+        # Get DB connection and tables set up.
+        self.db_instance = DbUtils()
+        self.db_instance.initialize_db()
+        self.heartbeat_id = 0
+        self.message_id = 0
 
     def process_sdx_controller_json_msg(self, msg):
         if "Heart Beat" in str(msg):

--- a/sdx_lc/handlers/sdx_controller_msg_handler.py
+++ b/sdx_lc/handlers/sdx_controller_msg_handler.py
@@ -1,0 +1,81 @@
+import json
+import logging
+import requests
+import os
+
+logger = logging.getLogger(__name__)
+
+OXP_CONNECTION_URL = os.environ.get("OXP_CONNECTION_URL")
+
+
+def is_json(myjson):
+    try:
+        json.loads(myjson)
+    except ValueError as e:
+        return False
+    return True
+
+
+class SdxControllerMsgHandler:
+    def __init__(self, db_instance):
+        self.db_instance = db_instance
+
+    def process_sdx_controller_json_msg(self, msg):
+        if "Heart Beat" in str(msg):
+            self.heartbeat_id += 1
+            self.logger.debug("Heart beat received. ID: " + str(self.heartbeat_id))
+            return
+
+        self.logger.info("MQ received message:" + str(msg))
+
+        if not is_json(msg):
+            self.logger.info("Other type of message")
+            self.db_instance.add_key_value_pair_to_db(self.message_id, msg)
+            self.logger.info("Save to database complete.")
+            self.logger.info("Message ID:" + str(self.message_id))
+            self.message_id += 1
+            return
+
+        self.logger.info("JSON message")
+        msg_json = json.loads(msg)
+        if (
+            "link" in msg_json
+            and "uni_a" in msg_json["link"]
+            and "uni_z" in msg_json["link"]
+        ):
+            connection = msg_json["link"]
+            self.logger.info("Got connection message.")
+            self.db_instance.add_key_value_pair_to_db(self.message_id, connection)
+            self.logger.info("Save to database complete.")
+            self.logger.info("Message ID:" + str(self.message_id))
+            self.message_id += 1
+            self.logger.info("Sending connection info to OXP.")
+            # send connection info to OXP
+            if msg_json.get("operation") == "post":
+                try:
+                    r = requests.post(str(OXP_CONNECTION_URL), json=connection)
+                    self.logger.info(f"Status from OXP: {r}")
+                except Exception as e:
+                    self.logger.error(f"Error on POST to {OXP_CONNECTION_URL}: {e}")
+                    self.logger.info(
+                        "Check your configuration and make sure OXP service is running."
+                    )
+            elif msg_json.get("operation") == "delete":
+                try:
+                    r = requests.delete(str(OXP_CONNECTION_URL), json=connection)
+                    self.logger.info(f"Status from OXP: {r}")
+                except Exception as e:
+                    self.logger.error(f"Error on DELETE {OXP_CONNECTION_URL}: {e}")
+                    self.logger.info(
+                        "Check your configuration and make sure OXP service is running."
+                    )
+        elif "version" in msg_json:
+            msg_id = msg_json["id"]
+            lc_name = msg_json["name"]
+            msg_version = msg_json["version"]
+            db_msg_id = str(lc_name) + "-" + str(msg_id) + "-" + str(msg_version)
+            self.db_instance.add_key_value_pair_to_db(db_msg_id, msg)
+            self.logger.info("Save to database complete.")
+            self.logger.info("message ID:" + str(db_msg_id))
+        else:
+            self.logger.info("Got message: " + str(msg))

--- a/sdx_lc/handlers/sdx_controller_msg_handler.py
+++ b/sdx_lc/handlers/sdx_controller_msg_handler.py
@@ -58,7 +58,7 @@ class SdxControllerMsgHandler:
             self.logger.info("Message ID:" + str(self.message_id))
             self.message_id += 1
             return
-        
+
         msg_json = json.loads(msg)
 
         if (

--- a/sdx_lc/jobs/pull_topo_changes.py
+++ b/sdx_lc/jobs/pull_topo_changes.py
@@ -82,7 +82,7 @@ def process_domain_controller_topo(db_instance):
         db_instance.add_key_value_pair_to_db("latest_topology_ts", str(topology_ts))
         logger.debug("Added pulled topo to db")
         # initiate rpc producer with 5 seconds timeout
-        rpc_producer = RpcProducer(5, "", "topo")
+        rpc_producer = RpcProducer(5, "", "oxp_update")
         # publish topology to message queue for sdx-controller
         response = rpc_producer.call(json.dumps(json_pulled_topology))
         # Signal to end keep alive pings.

--- a/sdx_lc/messaging/topic_queue_consumer.py
+++ b/sdx_lc/messaging/topic_queue_consumer.py
@@ -9,8 +9,6 @@ import pika
 from sdx_lc.handlers.sdx_controller_msg_handler import SdxControllerMsgHandler
 
 
-from sdx_lc.utils.db_utils import DbUtils
-
 MQ_HOST = os.environ.get("MQ_HOST")
 MQ_PORT = os.environ.get("MQ_PORT")
 MQ_USER = os.environ.get("MQ_USER")

--- a/sdx_lc/messaging/topic_queue_consumer.py
+++ b/sdx_lc/messaging/topic_queue_consumer.py
@@ -35,14 +35,7 @@ class TopicQueueConsumer(object):
         self._thread_queue = thread_queue
 
         self.routing_key = os.getenv("SDXLC_DOMAIN")
-
-        # Get DB connection and tables set up.
-        self.db_instance = DbUtils()
-        self.db_instance.initialize_db()
-        self.sdx_controller_msg_handler = SdxControllerMsgHandler(self.db_instance)
-
-        self.heartbeat_id = 0
-        self.message_id = 0
+        self.sdx_controller_msg_handler = SdxControllerMsgHandler()
 
     def on_rpc_request(self, ch, method, props, message_body):
         response = message_body

--- a/sdx_lc/messaging/topic_queue_consumer.py
+++ b/sdx_lc/messaging/topic_queue_consumer.py
@@ -8,7 +8,6 @@ import pika
 
 from sdx_lc.handlers.sdx_controller_msg_handler import SdxControllerMsgHandler
 
-
 MQ_HOST = os.environ.get("MQ_HOST")
 MQ_PORT = os.environ.get("MQ_PORT")
 MQ_USER = os.environ.get("MQ_USER")


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-lc/issues/162

After placing the connection, LC will send the OXP's HTTP response to SDX controller via MQ, so SDX controller will update the connection to include the OXP's response.

For simplicity, it may not make sense to create a separate queue just for sending the OXP connection response, so I repurposed the "topo" queue to do both topology reporting and OXP response reporting. The queue name is changed to "oxp_update", which may make more sense.