### PR TITLE
Change min and max allowed values for longitude

### DIFF
--- a/sdx_lc/swagger/swagger.yaml
+++ b/sdx_lc/swagger/swagger.yaml
@@ -1183,8 +1183,8 @@ components:
           maximum: 90.0
         longitude:
           type: number
-          minimum: -90.0
-          maximum: 90.0
+          minimum: -180.0
+          maximum: 180.0
         iso3166_2_lvl4:
           type: string
           minLength: 5


### PR DESCRIPTION
Fix #170 

### Description of the change

According to the last All Hands Meeting discussion regarding the allowed range for Longitude Location object, this PR modifies the allowed values.