### PR TITLE
Fix min and max length for iso3166_2_lvl4 attribute

### DIFF
--- a/sdx_lc/swagger/swagger.yaml
+++ b/sdx_lc/swagger/swagger.yaml
@@ -1187,8 +1187,8 @@ components:
           maximum: 90.0
         iso3166_2_lvl4:
           type: string
-          minLength: 5
-          maxLength: 5
+          minLength: 4
+          maxLength: 6
           pattern: '^[A-Z]{2}-[a-zA-Z0-9]{1,3}$'
         private:
           type: array


### PR DESCRIPTION
Fix #165 

### Description of the change

According to the Topology data model spec, the iso3166_2_lvl4 should be composed by a 2 alphanumeric  characters representing the country code + "-" + up to three alpha chars obtained from national sources and stems from coding systems already in use in the country concerned. The regex code for this attribute was correct, but the min and max length were not comply with the spec.

This PR fixes the min and max length for the iso3166_2_lvl4 attribute.