### PR TITLE
Add support for authenticated OXPO

### DIFF
--- a/sdx_lc/handlers/sdx_controller_msg_handler.py
+++ b/sdx_lc/handlers/sdx_controller_msg_handler.py
@@ -9,6 +9,8 @@ from sdx_lc.utils.db_utils import DbUtils
 
 logger = logging.getLogger(__name__)
 
+OXP_USER = os.environ.get("OXP_USER", None)
+OXP_PASS = os.environ.get("OXP_PASS", None)
 OXP_CONNECTION_URL = os.environ.get("OXP_CONNECTION_URL")
 PUB_QUEUE = os.environ.get("PUB_QUEUE")
 
@@ -80,7 +82,7 @@ class SdxControllerMsgHandler:
             if msg_json.get("operation") == "post":
                 try:
                     oxp_response = requests.post(
-                        str(OXP_CONNECTION_URL), json=connection
+                        str(OXP_CONNECTION_URL), json=connection, auth=(OXP_USER, OXP_PASS)
                     )
                 except Exception as e:
                     self.logger.error(f"Error on POST to {OXP_CONNECTION_URL}: {e}")
@@ -92,7 +94,7 @@ class SdxControllerMsgHandler:
             elif msg_json.get("operation") == "delete":
                 try:
                     oxp_response = requests.delete(
-                        str(OXP_CONNECTION_URL), json=connection
+                        str(OXP_CONNECTION_URL), json=connection, auth=(OXP_USER, OXP_PASS)
                     )
                 except Exception as e:
                     self.logger.error(f"Error on DELETE {OXP_CONNECTION_URL}: {e}")

--- a/sdx_lc/handlers/sdx_controller_msg_handler.py
+++ b/sdx_lc/handlers/sdx_controller_msg_handler.py
@@ -82,7 +82,9 @@ class SdxControllerMsgHandler:
             if msg_json.get("operation") == "post":
                 try:
                     oxp_response = requests.post(
-                        str(OXP_CONNECTION_URL), json=connection, auth=(OXP_USER, OXP_PASS)
+                        str(OXP_CONNECTION_URL),
+                        json=connection,
+                        auth=(OXP_USER, OXP_PASS),
                     )
                 except Exception as e:
                     self.logger.error(f"Error on POST to {OXP_CONNECTION_URL}: {e}")
@@ -94,7 +96,9 @@ class SdxControllerMsgHandler:
             elif msg_json.get("operation") == "delete":
                 try:
                     oxp_response = requests.delete(
-                        str(OXP_CONNECTION_URL), json=connection, auth=(OXP_USER, OXP_PASS)
+                        str(OXP_CONNECTION_URL),
+                        json=connection,
+                        auth=(OXP_USER, OXP_PASS),
                     )
                 except Exception as e:
                     self.logger.error(f"Error on DELETE {OXP_CONNECTION_URL}: {e}")

--- a/sdx_lc/jobs/pull_topo_changes.py
+++ b/sdx_lc/jobs/pull_topo_changes.py
@@ -3,6 +3,7 @@ import logging
 import os.path
 import sys
 import time
+
 import requests
 
 # append abspath, so this file can import other modules from parent directory

--- a/sdx_lc/jobs/pull_topo_changes.py
+++ b/sdx_lc/jobs/pull_topo_changes.py
@@ -3,7 +3,7 @@ import logging
 import os.path
 import sys
 import time
-import urllib.request
+import requests
 
 # append abspath, so this file can import other modules from parent directory
 sys.path.append(
@@ -13,6 +13,8 @@ sys.path.append(
 from messaging.rpc_queue_producer import RpcProducer
 from utils.db_utils import DbUtils
 
+OXPO_USER = os.environ.get("OXPO_USER", None)
+OXPO_PASS = os.environ.get("OXPO_PASS", None)
 OXP_PULL_URL = os.environ.get("OXP_PULL_URL")
 OXP_PULL_INTERVAL = os.environ.get("OXP_PULL_INTERVAL")
 PUB_QUEUE = os.environ.get("PUB_QUEUE")
@@ -49,18 +51,18 @@ def process_domain_controller_topo(db_instance):
             logger.debug("Latest topology does not exist")
 
         try:
-            pulled_topology = urllib.request.urlopen(OXP_PULL_URL).read()
-        except (urllib.request.URLError, ConnectionResetError):
+            pulled_topology = requests.get(OXP_PULL_URL, auth=(OXPO_USER, OXPO_PASS))
+        except (requests.ConnectionError, requests.HTTPError):
             logger.debug("Error connecting to domain controller...")
             continue
 
-        if not pulled_topology:
+        if not pulled_topology.ok:
             continue
 
         logger.debug("Pulled request from domain controller")
 
         try:
-            json_pulled_topology = json.loads(pulled_topology)
+            json_pulled_topology = pulled_topology.json()
         except ValueError:
             logger.debug("Cannot parse pulled topology, invalid JSON")
             continue


### PR DESCRIPTION
This PR introduces the capability of supporting authenticated OXPs, based on HTTP Basic Authentication. Future work can be developed to also add extra authentication mechanism. However the current implementation will be enough to support Kytos use case in production.