### PR TITLE
Adding log level configuration from env variable

### DIFF
--- a/sdx_lc/app.py
+++ b/sdx_lc/app.py
@@ -46,11 +46,12 @@ def create_app():
     logging.getLogger("pika").setLevel(logging.WARNING)
 
     log_file = os.getenv("LOG_FILE")
+    log_level = logging.getLevelName(os.getenv("LOG_LEVEL", "DEBUG"))
 
     if log_file:
-        logging.basicConfig(filename=log_file, level=logging.DEBUG)
+        logging.basicConfig(filename=log_file, level=log_level)
     else:
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig(level=log_level)
 
     logger.info(
         f"SDX Local Controller starting up ("

--- a/sdx_lc/utils/db_utils.py
+++ b/sdx_lc/utils/db_utils.py
@@ -30,8 +30,9 @@ class DbUtils(object):
         if not self.config_table_name:
             raise Exception("DB_CONFIG_TABLE_NAME environment variable is not set")
 
+        log_level = logging.getLevelName(os.getenv("LOG_LEVEL", "DEBUG"))
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(logging.DEBUG)
+        self.logger.setLevel(log_level)
 
         mongo_user = os.getenv("MONGO_USER") or "guest"
         mongo_pass = os.getenv("MONGO_PASS") or "guest"


### PR DESCRIPTION
Fix #176 

### Description of the change

As discussed during the All Hands Meeting, it would be nice if we have means to change the log level of the SDX components for production environment. In production, having the log level hardcoded to DEBUG is not recommended. With this PR, the SDX-LC operator can now set an environment variable called `LOG_LEVEL` and change this behavior.

For backward compatibility, the LOG_LEVEL defaults to "DEBUG" just as current behavior.