### PR TITLE
Include lc name in rpc response

### DIFF
--- a/sdx_lc/handlers/sdx_controller_msg_handler.py
+++ b/sdx_lc/handlers/sdx_controller_msg_handler.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 OXP_USER = os.environ.get("OXP_USER", None)
 OXP_PASS = os.environ.get("OXP_PASS", None)
 OXP_CONNECTION_URL = os.environ.get("OXP_CONNECTION_URL")
-SDXLC_DOMAIN = os.environ.get("SDXLC_DOMAIN")
+SDXLC_DOMAIN = os.environ.get("SDXLC_DOMAIN", "")
 PUB_QUEUE = MessageQueueNames.OXP_UPDATE
 
 

--- a/sdx_lc/handlers/sdx_controller_msg_handler.py
+++ b/sdx_lc/handlers/sdx_controller_msg_handler.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 OXP_USER = os.environ.get("OXP_USER", None)
 OXP_PASS = os.environ.get("OXP_PASS", None)
 OXP_CONNECTION_URL = os.environ.get("OXP_CONNECTION_URL")
+SDXLC_DOMAIN = os.environ.get("SDXLC_DOMAIN")
 PUB_QUEUE = MessageQueueNames.OXP_UPDATE
 
 
@@ -36,6 +37,7 @@ class SdxControllerMsgHandler:
     def send_conn_response_to_sdx_controller(self, service_id, oxp_response):
         oxp_response_json = oxp_response.json()
         rpc_msg = {
+            "lc_domain": SDXLC_DOMAIN,
             "msg_type": "oxp_conn_response",
             "service_id": service_id,
             "oxp_response_code": oxp_response.status_code,


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-lc/issues/184

Include "lc_domain" in the RPC response so SDX controller can know which LC sent back the rpc response.