### PR TITLE
Adding validation rules for entities attributes on swagger

### DIFF
--- a/sdx_lc/swagger/swagger.yaml
+++ b/sdx_lc/swagger/swagger.yaml
@@ -1146,6 +1146,10 @@ components:
           enum: ['enabled', 'disabled', 'maintenance']
         services:
           $ref: '#/components/schemas/service'
+        entities:
+          type: array
+          items:
+            type: string
         private:
           type: array
           items:


### PR DESCRIPTION
Fix #178 

### Description of the change

This is a very simple PR which adds the entities attribute into swagger validation schema. Since LC will just forward the information received from OXP to SDX-Controller, no additional changes were necessary.

Kytos SDX Napp is already capable of sending the `entities` attribute (https://github.com/atlanticwave-sdx/kytos-sdx) and work is being done on sdx-continuous-development repo to also have those tests (https://github.com/atlanticwave-sdx/sdx-continuous-development/issues/121).