### PR TITLE
Augmented error handling on rabbitmq consumer thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - Unreleased
+
+### Added
+
+- TODO
+
+### Fixed
+
+- Enhanced error handler when processing OXP response to avoid non-json content from breaking the code (#192)
+- Augmented general error handler when processing rabbitmq messages to avoid breaking the consumer (#192)
+
+### Changed
+
+- TODO
+
+### Removed
+
+- TODO
+
+
 ## [2.0.0] - 2023-05-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sdx-lc"
-version = "3.0.0.dev0"
+version = "3.0.0.dev1"
 description = "AtlanticWave-SDX project's local controller"
 authors = [
     { name = "Yufeng Xin", email = "yxin@renci.org" },

--- a/sdx_lc/handlers/sdx_controller_msg_handler.py
+++ b/sdx_lc/handlers/sdx_controller_msg_handler.py
@@ -38,7 +38,9 @@ class SdxControllerMsgHandler:
         try:
             oxp_response_json = oxp_response.json()
         except:
-            oxp_response_json = {"msg": "Failed to parse OXP response. Please check the OXP logs."}
+            oxp_response_json = {
+                "msg": "Failed to parse OXP response. Please check the OXP logs."
+            }
         rpc_msg = {
             "lc_domain": SDXLC_DOMAIN,
             "msg_type": "oxp_conn_response",

--- a/sdx_lc/handlers/sdx_controller_msg_handler.py
+++ b/sdx_lc/handlers/sdx_controller_msg_handler.py
@@ -35,7 +35,10 @@ class SdxControllerMsgHandler:
         self.message_id = 0
 
     def send_conn_response_to_sdx_controller(self, service_id, operation, oxp_response):
-        oxp_response_json = oxp_response.json()
+        try:
+            oxp_response_json = oxp_response.json()
+        except:
+            oxp_response_json = {"msg": "Failed to parse OXP response. Please check the OXP logs."}
         rpc_msg = {
             "lc_domain": SDXLC_DOMAIN,
             "msg_type": "oxp_conn_response",

--- a/sdx_lc/messaging/topic_queue_consumer.py
+++ b/sdx_lc/messaging/topic_queue_consumer.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import threading
+import traceback
 from queue import Queue
 
 import pika
@@ -57,7 +58,11 @@ class TopicQueueConsumer(object):
         ch.basic_ack(delivery_tag=method.delivery_tag)
 
     def callback(self, ch, method, properties, body):
-        self.sdx_controller_msg_handler.process_sdx_controller_json_msg(body)
+        try:
+            self.sdx_controller_msg_handler.process_sdx_controller_json_msg(body)
+        except Exception as exc:
+            err = traceback.format_exc().replace("\n", ", ")
+            self.logger.error(f"Failed to process msg: {exc} - {err}")
 
     def start_consumer(self):
         # self.channel.queue_declare(queue=SUB_QUEUE)


### PR DESCRIPTION
Fix #192 

### Description of the change

- Enhanced error handler when processing OXP response to avoid non-json content from breaking the code
- Augmented general error handler when processing rabbitmq messages to avoid breaking the consumer

### Local tests

With the fix applied and following the steps documented on the issue, we get the following result:
```
$ docker compose exec -it mininet curl -s -X POST -H 'Content-type: application/json' http://sdx-controller:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "vlan test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "999"}, {"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "999"}]}'
{
  "reason": "Connection published",
  "service_id": "1e123abc-11f0-4a42-bb20-af6234dc2f33",
  "status": "under provisioning"
}
$ ./show-sdx-controller.sh l2vpn
ID                                    STATUS  ENDPOINT-1                          VLAN-1  ENDPOINT-2                     VLAN-2
--                                    ------  ----------                          ------  ----------                     ------
1e123abc-11f0-4a42-bb20-af6234dc2f33  down    urn:sdx:port:ampath.net:Ampath3:50  999     urn:sdx:port:sax.net:Sax01:50  999
eb35c709-d588-49f4-a822-78ab10ee1ca9  up      urn:sdx:port:ampath.net:Ampath3:50  2990    urn:sdx:port:sax.net:Sax01:50  2990
$ docker compose logs ampath-lc -t
ampath-lc-1  | 2025-08-22T20:34:58.141855349Z INFO:sdx_lc.handlers.sdx_controller_msg_handler:MQ received message:b'{"operation": "post", "service_id": "1e123abc-11f0-4a42-bb20-af6234dc2f33", "link": {"name": "AMPATH_vlan_999_2", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 999, "tag_type": 1}, "port_id": "urn:sdx:port:ampath.net:Ampath3:50"}, "uni_z": {"tag": {"value": 2, "tag_type": 1}, "port_id": "urn:sdx:port:ampath.net:Ampath1:40"}}}'
ampath-lc-1  | 2025-08-22T20:34:58.141929616Z INFO:sdx_lc.handlers.sdx_controller_msg_handler:Got connection message.
ampath-lc-1  | 2025-08-22T20:34:58.143049029Z DEBUG:sdx_lc.utils.db_utils:Updating DB entry.
ampath-lc-1  | 2025-08-22T20:34:58.144017359Z INFO:sdx_lc.handlers.sdx_controller_msg_handler:Save to database complete.
ampath-lc-1  | 2025-08-22T20:34:58.144026567Z INFO:sdx_lc.handlers.sdx_controller_msg_handler:Message ID:0
ampath-lc-1  | 2025-08-22T20:34:58.144030641Z INFO:sdx_lc.handlers.sdx_controller_msg_handler:Sending connection info to OXP.
ampath-lc-1  | 2025-08-22T20:34:58.145665986Z DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): ampath:8181
ampath-lc-1  | 2025-08-22T20:34:58.153580936Z DEBUG:urllib3.connectionpool:http://ampath:8181 "POST /api/kytos/sdx/v1/l2vpn_ptp HTTP/1.1" 500 2579
ampath-lc-1  | 2025-08-22T20:34:58.153981422Z INFO:sdx_lc.handlers.sdx_controller_msg_handler:Status from OXP: <Response [500]> - Traceback (most recent call last):
ampath-lc-1  | 2025-08-22T20:34:58.153996153Z   File "/usr/local/lib/python3.11/dist-packages/starlette/middleware/errors.py", line 164, in __call__
ampath-lc-1  | 2025-08-22T20:34:58.154001044Z     await self.app(scope, receive, _send)
ampath-lc-1  | 2025-08-22T20:34:58.154004864Z   File "/usr/local/lib/python3.11/dist-packages/starlette/middleware/cors.py", line 83, in __call__
ampath-lc-1  | 2025-08-22T20:34:58.154009178Z     await self.app(scope, receive, send)
ampath-lc-1  | 2025-08-22T20:34:58.154013158Z   File "/usr/local/lib/python3.11/dist-packages/starlette/middleware/exceptions.py", line 62, in __call__
ampath-lc-1  | 2025-08-22T20:34:58.154017043Z     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
ampath-lc-1  | 2025-08-22T20:34:58.154020797Z   File "/usr/local/lib/python3.11/dist-packages/starlette/_exception_handler.py", line 55, in wrapped_app
ampath-lc-1  | 2025-08-22T20:34:58.154024835Z     raise exc
ampath-lc-1  | 2025-08-22T20:34:58.154028513Z   File "/usr/local/lib/python3.11/dist-packages/starlette/_exception_handler.py", line 44, in wrapped_app
ampath-lc-1  | 2025-08-22T20:34:58.154032272Z     await app(scope, receive, sender)
ampath-lc-1  | 2025-08-22T20:34:58.154035835Z   File "/usr/local/lib/python3.11/dist-packages/starlette/routing.py", line 746, in __call__
ampath-lc-1  | 2025-08-22T20:34:58.154039632Z     await route.handle(scope, receive, send)
ampath-lc-1  | 2025-08-22T20:34:58.154043310Z   File "/usr/local/lib/python3.11/dist-packages/starlette/routing.py", line 288, in handle
ampath-lc-1  | 2025-08-22T20:34:58.154047166Z     await self.app(scope, receive, send)
ampath-lc-1  | 2025-08-22T20:34:58.154050705Z   File "/usr/local/lib/python3.11/dist-packages/starlette/routing.py", line 75, in app
ampath-lc-1  | 2025-08-22T20:34:58.154054708Z     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
ampath-lc-1  | 2025-08-22T20:34:58.154059035Z   File "/usr/local/lib/python3.11/dist-packages/starlette/_exception_handler.py", line 55, in wrapped_app
ampath-lc-1  | 2025-08-22T20:34:58.154063195Z     raise exc
ampath-lc-1  | 2025-08-22T20:34:58.154066665Z   File "/usr/local/lib/python3.11/dist-packages/starlette/_exception_handler.py", line 44, in wrapped_app
ampath-lc-1  | 2025-08-22T20:34:58.154070417Z     await app(scope, receive, sender)
ampath-lc-1  | 2025-08-22T20:34:58.154074379Z   File "/usr/local/lib/python3.11/dist-packages/starlette/routing.py", line 72, in app
ampath-lc-1  | 2025-08-22T20:34:58.154078634Z     response = await run_in_threadpool(func, request)
ampath-lc-1  | 2025-08-22T20:34:58.154082254Z                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ampath-lc-1  | 2025-08-22T20:34:58.154085874Z   File "/usr/local/lib/python3.11/dist-packages/starlette/concurrency.py", line 35, in run_in_threadpool
ampath-lc-1  | 2025-08-22T20:34:58.154089792Z     return await anyio.to_thread.run_sync(func, *args)
ampath-lc-1  | 2025-08-22T20:34:58.154093369Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ampath-lc-1  | 2025-08-22T20:34:58.154097009Z   File "/usr/local/lib/python3.11/dist-packages/anyio/to_thread.py", line 56, in run_sync
ampath-lc-1  | 2025-08-22T20:34:58.154112342Z     return await get_async_backend().run_sync_in_worker_thread(
ampath-lc-1  | 2025-08-22T20:34:58.154116547Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ampath-lc-1  | 2025-08-22T20:34:58.154123309Z   File "/usr/local/lib/python3.11/dist-packages/anyio/_backends/_asyncio.py", line 2144, in run_sync_in_worker_thread
ampath-lc-1  | 2025-08-22T20:34:58.154127249Z     return await future
ampath-lc-1  | 2025-08-22T20:34:58.154130900Z            ^^^^^^^^^^^^
ampath-lc-1  | 2025-08-22T20:34:58.154134526Z   File "/usr/local/lib/python3.11/dist-packages/anyio/_backends/_asyncio.py", line 851, in run
ampath-lc-1  | 2025-08-22T20:34:58.154138289Z     result = context.run(func, *args)
ampath-lc-1  | 2025-08-22T20:34:58.154141893Z              ^^^^^^^^^^^^^^^^^^^^^^^^
ampath-lc-1  | 2025-08-22T20:34:58.154145535Z   File "//var/lib/kytos/napps/kytos/sdx/main.py", line 707, in create_l2vpn_ptp
ampath-lc-1  | 2025-08-22T20:34:58.154149408Z     raise ValueError("error on purpose")
ampath-lc-1  | 2025-08-22T20:34:58.154153238Z ValueError: error on purpose
ampath-lc-1  | 2025-08-22T20:34:58.154156918Z
ampath-lc-1  | 2025-08-22T20:34:59.225305990Z DEBUG:sdx_lc.handlers.sdx_controller_msg_handler:Sent OXP connection response to SDX controller via MQ. MQ response: b'b\'{"lc_domain": "ampath.net", "msg_type": "oxp_conn_response", "service_id": "1e123abc-11f0-4a42-bb20-af6234dc2f33", "operation": "post", "oxp_response_code": 500, "oxp_response": {"msg": "Failed to parse OXP response. Please check the OXP logs."}}\''

```

Then we can continue to create L2VPN and SDX-LC messages consumer continues to work:

```
$ docker compose exec -it mininet curl -s -X POST -H 'Content-type: application/json' http://sdx-controller:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "vlan test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "100"}, {"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "100"}]}'
{
  "reason": "Connection published",
  "service_id": "cf3f362d-0d14-4006-9f76-89cbd1ef4575",
  "status": "under provisioning"
}
$ docker compose exec -it mininet curl -s -X POST -H 'Content-type: application/json' http://sdx-controller:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "vlan test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "200"}, {"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "200"}]}'
{
  "reason": "Connection published",
  "service_id": "2be2ebc5-e6e3-4dbd-b4ce-fd23d7f5f256",
  "status": "under provisioning"
}
$ ./show-sdx-controller.sh l2vpn
ID                                    STATUS  ENDPOINT-1                          VLAN-1  ENDPOINT-2                     VLAN-2
--                                    ------  ----------                          ------  ----------                     ------
1e123abc-11f0-4a42-bb20-af6234dc2f33  down    urn:sdx:port:ampath.net:Ampath3:50  999     urn:sdx:port:sax.net:Sax01:50  999
2be2ebc5-e6e3-4dbd-b4ce-fd23d7f5f256  up      urn:sdx:port:ampath.net:Ampath3:50  200     urn:sdx:port:sax.net:Sax01:50  200
cf3f362d-0d14-4006-9f76-89cbd1ef4575  up      urn:sdx:port:ampath.net:Ampath3:50  100     urn:sdx:port:sax.net:Sax01:50  100
eb35c709-d588-49f4-a822-78ab10ee1ca9  up      urn:sdx:port:ampath.net:Ampath3:50  2990    urn:sdx:port:sax.net:Sax01:50  2990
```

### End-to-end tests

Here is the setup:

```
~/sdx-end-to-end-tests$ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   docker-compose.yml

~/sdx-end-to-end-tests$ git diff docker-compose.yml
diff --git a/docker-compose.yml b/docker-compose.yml
index 8b430f2..faa6c45 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       - .env
     volumes:
       - .:/sdx-end-to-end-tests
+      - ./sdx-lc/sdx_lc:/usr/src/app/sdx_lc
     depends_on:
       mongo:
         condition: service_healthy
@@ -112,6 +113,7 @@ services:
       - .env
     volumes:
       - .:/sdx-end-to-end-tests
+      - ./sdx-lc/sdx_lc:/usr/src/app/sdx_lc
     depends_on:
       mongo:
         condition: service_healthy
@@ -135,6 +137,7 @@ services:
       - .env
     volumes:
       - .:/sdx-end-to-end-tests
+      - ./sdx-lc/sdx_lc:/usr/src/app/sdx_lc
     depends_on:
       mongo:
         condition: service_healthy
```

And here are the results:


```
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0+repack
rootdir: /sdx-end-to-end-tests
plugins: unordered-0.7.0
collected 95 items

tests/test_01_topology.py .....                                          [  5%]
tests/test_05_l2vpn.py ........                                          [ 13%]
tests/test_06_l2vpn_return_codes.py ..................................   [ 49%]
tests/test_07_l2vpn_return_codes.py .......................              [ 73%]
tests/test_08_l2vpn_return_codes.py ......                               [ 80%]
tests/test_20_use_case_topology.py xx.x.xx....x                          [ 92%]
tests/test_21_use_case_topology.py x.xx                                  [ 96%]
tests/test_99_topology_big_changes.py ...                                [100%]

------------------------------- start/stop times -------------------------------
================== 86 passed, 9 xfailed in 1679.11s (0:27:59) ==================
```