### PR TITLE
Include domain in heartbeat

### DIFF
--- a/env.template
+++ b/env.template
@@ -3,6 +3,7 @@
 # SDX-LC settings
 SDXLC_NAME=lc1
 SDXLC_DOMAIN=amlight.net
+HEARTBEAT_INTERVAL=30
 
 # change to local controller host name
 SDXLC_HOST=aw-sdx-lc-1.renci.org

--- a/sdx_lc/messaging/rpc_queue_producer.py
+++ b/sdx_lc/messaging/rpc_queue_producer.py
@@ -13,6 +13,7 @@ MQ_PORT = os.environ.get("MQ_PORT")
 MQ_USER = os.environ.get("MQ_USER")
 MQ_PASS = os.environ.get("MQ_PASS")
 SDXLC_DOMAIN = os.environ.get("SDXLC_DOMAIN")
+HEARTBEAT_INTERVAL = int(os.getenv("HEARTBEAT_INTERVAL", 30))  # seconds
 
 
 class RpcProducer(object):
@@ -55,7 +56,7 @@ class RpcProducer(object):
 
     def keep_live(self):
         while self.stop_keep_live != True:
-            time.sleep(30)
+            time.sleep(HEARTBEAT_INTERVAL)
             msg = {"type": "Heart Beat", "domain": SDXLC_DOMAIN}
             self.logger.debug("Sending heart beat msg.")
             self.call(json.dumps(msg))


### PR DESCRIPTION
Include domain name when sending heartbeat to sdx controller. Linked to this PR: https://github.com/atlanticwave-sdx/sdx-controller/pull/499/