### PR TITLE
fix link name size according to topology spec 2.0.0-minor2

### DIFF
--- a/sdx_lc/swagger/swagger.yaml
+++ b/sdx_lc/swagger/swagger.yaml
@@ -1057,7 +1057,7 @@ components:
           pattern: '^urn:sdx:link:[A-Za-z0-9_,./-]*:[A-Za-z0-9_.,/-]*$'
         name:
           type: string
-          maxLength: 30
+          maxLength: 100
           pattern: '^[A-Za-z0-9_.,/-]*$'
         ports:
           type: array


### PR DESCRIPTION
As per our recent discussions, we agreed that Link's name should allow values bigger than 30 characters. 