### PR TITLE
Non blocking heartbeat

### DIFF
--- a/sdx_lc/app.py
+++ b/sdx_lc/app.py
@@ -13,9 +13,12 @@ from sdx_datamodel.constants import MessageQueueNames
 
 from sdx_lc import encoder
 from sdx_lc.messaging.topic_queue_consumer import TopicQueueConsumer
+from sdx_lc.messaging.heartbeat_producer import HeartbeatProducer
 from sdx_lc.utils.db_utils import DbUtils
 
 SUB_QUEUE = MessageQueueNames.CONNECTIONS
+
+_heartbeat_producer = None
 
 
 def start_consumer(thread_queue, db_instance):
@@ -30,6 +33,15 @@ def start_consumer(thread_queue, db_instance):
     rpc = TopicQueueConsumer(thread_queue=thread_queue, exchange_name=SUB_QUEUE)
     t1 = threading.Thread(target=rpc.start_consumer, args=())
     t1.start()
+
+
+def start_heartbeat():
+    global _heartbeat_producer
+    _heartbeat_producer = HeartbeatProducer(
+        exchange_name="",
+        routing_key=MessageQueueNames.HEARTBEATS
+    )
+    _heartbeat_producer.start()
 
 
 def start_pull_topology_change():
@@ -59,6 +71,9 @@ def create_app():
         f"name: {os.getenv('SDXLC_NAME')}, "
         f"domain: {os.getenv('SDXLC_DOMAIN')})"
     )
+
+    heartbeat_thread = threading.Thread(target=start_heartbeat)
+    heartbeat_thread.start()
 
     # Run swagger service
     app = connexion.App(__name__, specification_dir="./swagger/")

--- a/sdx_lc/app.py
+++ b/sdx_lc/app.py
@@ -12,8 +12,8 @@ from flask import redirect
 from sdx_datamodel.constants import MessageQueueNames
 
 from sdx_lc import encoder
-from sdx_lc.messaging.topic_queue_consumer import TopicQueueConsumer
 from sdx_lc.messaging.heartbeat_producer import HeartbeatProducer
+from sdx_lc.messaging.topic_queue_consumer import TopicQueueConsumer
 from sdx_lc.utils.db_utils import DbUtils
 
 SUB_QUEUE = MessageQueueNames.CONNECTIONS

--- a/sdx_lc/app.py
+++ b/sdx_lc/app.py
@@ -38,8 +38,7 @@ def start_consumer(thread_queue, db_instance):
 def start_heartbeat():
     global _heartbeat_producer
     _heartbeat_producer = HeartbeatProducer(
-        exchange_name="",
-        routing_key=MessageQueueNames.HEARTBEATS
+        exchange_name="", routing_key=MessageQueueNames.HEARTBEATS
     )
     _heartbeat_producer.start()
 

--- a/sdx_lc/messaging/heartbeat_producer.py
+++ b/sdx_lc/messaging/heartbeat_producer.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+import json
+import logging
+import os
+import threading
+import time
+from datetime import datetime
+
+import pika
+
+MQ_HOST = os.environ.get("MQ_HOST")
+MQ_PORT = os.environ.get("MQ_PORT")
+MQ_USER = os.environ.get("MQ_USER")
+MQ_PASS = os.environ.get("MQ_PASS")
+SDXLC_DOMAIN = os.environ.get("SDXLC_DOMAIN")
+HEARTBEAT_INTERVAL = int(os.getenv("HEARTBEAT_INTERVAL", 30))  # seconds
+
+
+class HeartbeatProducer:
+    """
+    Process-level heartbeat sender.
+    One instance per LC process.
+    """
+
+    def __init__(self, exchange_name="", routing_key=""):
+        self.logger = logging.getLogger(__name__)
+        self.exchange_name = exchange_name
+        self.routing_key = routing_key
+        self._stop_event = threading.Event()
+
+        self.connection = pika.BlockingConnection(
+            pika.ConnectionParameters(
+                host=MQ_HOST,
+                port=MQ_PORT,
+                credentials=pika.PlainCredentials(username=MQ_USER, password=MQ_PASS),
+            )
+        )
+        self.channel = self.connection.channel()
+
+        self.logger.info("HeartbeatProducer started")
+
+    def _build_msg(self):
+        return {
+            "type": "Heart Beat",
+            "domain": SDXLC_DOMAIN,
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+        }
+
+    def _run(self):
+        # Send immediately on startup
+        self._send_once()
+
+        while not self._stop_event.wait(HEARTBEAT_INTERVAL):
+            self._send_once()
+
+    def _send_once(self):
+        try:
+            msg = self._build_msg()
+            self.channel.basic_publish(
+                exchange=self.exchange_name,
+                routing_key=self.routing_key,
+                body=json.dumps(msg),
+            )
+            self.logger.info(f"Heartbeat sent: {msg['timestamp']}")
+        except Exception as e:
+            self.logger.error(f"Heartbeat send failed: {e}")
+
+    def stop(self):
+        self.logger.info("Stopping HeartbeatProducer")
+        self._stop_event.set()
+        try:
+            if self.channel.is_open:
+                self.channel.close()
+        except Exception:
+            pass
+        try:
+            if self.connection.is_open:
+                self.connection.close()
+        except Exception:
+            pass
+
+    def start(self):
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()

--- a/sdx_lc/messaging/rpc_queue_producer.py
+++ b/sdx_lc/messaging/rpc_queue_producer.py
@@ -20,10 +20,7 @@ class RpcProducer(object):
             pika.ConnectionParameters(
                 host=MQ_HOST,
                 port=MQ_PORT,
-                credentials=pika.PlainCredentials(
-                    username=MQ_USER,
-                    password=MQ_PASS
-                ),
+                credentials=pika.PlainCredentials(username=MQ_USER, password=MQ_PASS),
             )
         )
 


### PR DESCRIPTION
Resolves: https://github.com/atlanticwave-sdx/sdx-lc/issues/201

At some point of time, we added function to close connection after publishing a topology message code [here](https://github.com/atlanticwave-sdx/sdx-lc/blob/2e665c769b96dcdcdb2b82d03ab5047345f76694/sdx_lc/controllers/topology_controller.py#L76). Since heartbeat shares the same MQ channel, heartbeat connection will also be stopped.

This PR moves heartbeat into a separate channel, so it'll not be closed when other messages are sent.